### PR TITLE
EXPERIMENT (AI-written, undecided): where and how should Rust be used in Babel?

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,7 +266,7 @@ ingest is in `docs/Development.md` ("Enhancing a data source ingest"); datahandl
   never export one that is called once per row, because crossing pyo3 per CURIE costs more than the
   Python it replaces. Every accelerated function keeps its Python implementation as the reference,
   with a test asserting the two agree, and is reached through `src/accel.py` (never `src._accel`
-  directly) so a missing extension falls back rather than breaking DAG parsing for all 245 rules.
+  directly) so a missing extension falls back rather than breaking DAG parsing for all 243 rules.
   Pick targets from a run's `benchmark:` TSVs, not by reading code — see
   [`docs/Rust.md`](docs/Rust.md), which also records the three targets chosen that way that turned
   out to be pure-Python bugs.

--- a/docs/Rust.md
+++ b/docs/Rust.md
@@ -1,7 +1,26 @@
 # Rust in Babel
 
-Babel's expensive rules are CPU-bound single-threaded Python. From the `babel-1.18` Snakemake
-`benchmark:` TSVs, the five costliest rules all run at ~100% of one core:
+> ## ⚠️ This document is an AI-written proposal. No human has reviewed or agreed to it.
+>
+> It was written by Claude (Claude Code) at @gaurav's request, to answer two questions that
+> [PR #975](https://github.com/NCATSTranslator/Babel/pull/975) leaves open: **where in Babel would
+> Rust actually help, and how should it be wired in?** It contains measurements, a recommendation,
+> and an argument against that recommendation.
+>
+> **Nothing here is a decision.** The options being compared are set out in
+> [How to integrate](#how-to-integrate) — in-process pyo3 (what #975 builds), a separate program at
+> a Snakemake rule boundary, splitting a rule at a new file boundary, or not using Rust at all. The
+> recommendation favours the second and third over the first; #975 currently implies the first.
+> Choosing between them is a call for @gaurav and @SkyeAv, who have not seen this yet.
+>
+> It also corrects two factual errors in an earlier AI-written version of this file, which is a
+> reason to check the rest rather than trust it. Every number below is reproducible from a committed
+> script or from `data/babel-1.18/babel_outputs/benchmarks/`.
+
+## Where the time actually goes
+
+From `babel-1.18`'s Snakemake `benchmark:` TSVs (354 rules, 83.7 h summed). All five costliest rules
+run at ~100% of a single core:
 
 | Rule | Wall | CPU | `mean_load` | `max_rss` |
 |------|------|-----|-------------|-----------|
@@ -11,37 +30,142 @@ Babel's expensive rules are CPU-bound single-threaded Python. From the `babel-1.
 | `geneprotein_conflated_synonyms` | 15,719 s | 15,702 s | 99.8% | 98 GB |
 | `gene_compendia` | 15,400 s | 15,178 s | 98.5% | 179 GB |
 
-The build backend is therefore [maturin](https://www.maturin.rs/), and the project builds as a
-mixed Rust/Python package: a `cdylib` crate under `rust/` compiled into `src/_accel`, alongside the
-ordinary Python in `src/`.
+## Rule 0: measure first, and expect the answer to be "fix the Python"
 
-## Rules for adding a Rust function
+Pick targets from the `benchmark:` TSVs of a real run, never by reading code for expensive-looking
+shapes. Check `mean_load` before assuming a slow rule is CPU-bound — `get_ensembl` is 6,665 s wall
+but only 257 s CPU, so no amount of Rust would touch it.
 
-**Measure first, from the benchmark TSVs.** Not from reading code for quadratic-looking shapes.
-Three candidate targets picked that way all turned out to be wrong: `SynonymFilter.should_suppress`
-looks like an O(labels × entries) scan but `input_data/obsolete_synonyms.yaml` holds three entries;
-concord parsing looks like the obvious string-manipulation target but runs 159,283 lines in
-0.148 s; and each genuinely expensive rule examined had a pure-Python defect (an eagerly evaluated
-f-string feeding a suppressed `logger.debug`, a missing `elem.clear()`) worth more than any port.
-Check `mean_load` before assuming a slow rule is CPU-bound — `get_ensembl` is 6,665 s wall but only
-257 s CPU, so Rust would do nothing for it.
+This is not generic advice. Every candidate examined so far has failed on contact with data:
 
-**The FFI boundary is coarse.** A `#[pyfunction]` takes a file path and returns the whole parsed
-result. It never takes one row. Crossing pyo3 once per CURIE costs more than the Python it
-replaces, so a per-row entry point would be *slower* while looking like an optimisation. This is
-enforced structurally: Rust functions open their own files, so there is no entry point that could
-accept a row.
+| Candidate | Looked like | Actually |
+|---|---|---|
+| `SynonymFilter.should_suppress` | O(labels × entries) scan with regexes | `obsolete_synonyms.yaml` holds **3 entries** |
+| concord parsing | the obvious string-manipulation target | **159,283 lines in 0.148 s** |
+| `parse_pubmed_into_tsvs` | needs a fast XML parser | fed the pull parser **one line at a time** and never called `elem.clear()`; fixing both gave **1.94× and 16× less memory**, in Python |
+| `conflate_synonyms` | JSON-heavy merge loop | serialised the entire in-memory structure to JSON for a **suppressed `logger.debug`**, twice more per record, plus a quadratic recompute |
 
-**Keep the Python implementation as the reference.** Every accelerated function keeps its Python
-version in the tree, and a unit test asserts the two produce identical output over the same input.
-The Python is the specification; the test is the proof the Rust matches it. This is also what makes
-the fallback below safe, and what lets a differential test be written before the Rust exists.
+Two more of the same kind are open, both in `write_compendium`'s setup, both untouched:
 
-**Bump `ABI_VERSION` in the same commit** as any change to an accelerated function's signature or
-semantics — in both `rust/src/lib.rs` and `_REQUIRED_ABI_VERSION` in `src/accel.py`. See
-"Staleness" below.
+- **`get_biolink_model_toolkit` (`util.py:405`) has no cache.** It constructs
+  `Toolkit(<raw.githubusercontent.com URL>)` on every call — a network fetch plus a linkml parse of
+  `biolink-model.yaml`. `NodeFactory.__init__` calls it, `write_compendium` constructs a
+  `NodeFactory` per call, and the chemical build calls `write_compendium` **8 times**
+  (`config.yaml: chemical_outputs`). Eight fetches and eight full model parses per build.
+- **`InformationContentFactory.__init__` (`node.py:368`) reads all of `icRDF.tsv`** — 3,940,399
+  lines, 212 MB — calling `curies.Converter.compress()` per line, and is likewise constructed per
+  `write_compendium` call. ~31.5 M `compress()` calls per chemical build, seven-eighths of them
+  repeating identical work.
 
-## Using it from Python
+`chemical_compendia` is 19,643 s. **Profile it with `py-spy` (already a dev dependency) before
+porting it to anything.** If it turns out to be factory-lookup-bound rather than compute-bound, Rust
+is not the answer there at all.
+
+## Where Rust would be most useful
+
+Ranked by expected value, after the Python fixes above:
+
+1. **`glom()`'s union-find — `babel_utils.py:1027`.** The strongest case in the codebase, and the
+   only one where the win is *memory* rather than speed. The dict-of-sets rewrites every member's
+   pointer on every merge (`:1159-1160`), and holds the state as Python objects: measured against
+   the anatomy build, glom's representation costs **73 MB resident for a clique state that
+   serialises to 4.8 MB — 15×**. That overhead is why `protein_compendia` and `chemical_compendia`
+   sit at 246 GB and 335 GB and need `mem="512G"` reservations. A disjoint-set over interned integer
+   IDs attacks the 500 GB headline directly, which nothing else here does.
+2. **`conflate_synonyms` — `synonymconflation.py:22`.** 7.1 h across two rules, stdlib-only, JSONL
+   in and JSONL out. But fix the discarded-work bugs and re-measure first; they may be most of it.
+3. **`write_compendium`'s per-clique loop — `babel_utils.py:780-1000`.** Millions of iterations of
+   CURIE splitting, prefix bucketing and JSON serialisation. Highest ceiling, but **profile before
+   believing it**, and it is the one place where a file boundary is awkward (see below).
+
+**Where Rust would not help, despite the size of the number:**
+
+- **`generate_pubmed_concords` (20 h) is probably a Snakemake refactor, not a Rust one.** It parses
+  ~1,500 *independent* `.xml.gz` files in a single rule at one core. Sharding it over a wildcard —
+  with a merge step for the accumulating `pmid_status` dict — is a plausible route to roughly an
+  hour with no Rust at all. There is also a separate effort to replace this rule with a parallel
+  DuckDB load, which would supersede either approach. **Do not port this to Rust.**
+- **Anything DuckDB already does.** `duckdb` is a dependency and already carries the entire export
+  half of the pipeline (`src/exporters/duckdb_exporters.py`). It is compiled, parallel, and arrives
+  as a prebuilt wheel that costs nobody a toolchain. For columnar aggregation and joins it beats
+  hand-written Rust on every axis including engineering time.
+
+## How to integrate
+
+Four shapes. They compose — this is not one global choice.
+
+| | Shape | Boundary | Who pays the build cost |
+|---|-------|----------|-------------------------|
+| **A** | in-process pyo3, one package (**what #975 builds**) | Python objects across FFI | everyone, every environment, forever |
+| **B** | standalone program invoked from `shell:` | a file, at an existing rule edge | only people who touch Rust |
+| **C** | split a rule at a *new* file boundary; implement one side in Rust | a file, at a new rule edge | only people who touch Rust |
+| **D** | no Rust — DuckDB and other native libraries already in the tree | in-process, prebuilt wheel | nobody |
+
+Neither B/C nor D is hypothetical. `untyped_chemical_compendia` → `chemical_compendia` is already
+exactly C, at the heaviest point in the pipeline, and `protein.py:272-273` carries a TODO wishing
+for the same split. `reports.snakefile:209-213` already invokes a console script from `shell:` with
+config-derived roots threaded in as `params:` — the precedent for how an out-of-process stage learns
+where the files are.
+
+### What the measurement says
+
+The one axis where A could beat B/C is the cost of getting data across. That was measured — see
+[`rust-decision/README.md`](./rust-decision/README.md) for the method, which credits pyo3 with a
+serialization cost of *zero* and compares against the unavoidable floor of building the Python
+objects. Extrapolated to the chemical pipeline's 256,427,006 CURIEs against
+`chemical_compendia`'s 19,643 s:
+
+- **Maximum possible saving from going in-process: ~4 minutes, 1.3% of the rule.** That is a
+  ceiling no pyo3 implementation can beat.
+- **Switching the existing `repr(set)`/`ast.literal_eval` boundary to JSONL would save ~9.5 minutes
+  — 2.2× more than in-process could ever save**, with no Rust involved.
+
+So boundary cost does not justify A. The remaining criteria do most of the work, and they are not
+about speed:
+
+| Criterion | Favours |
+|---|---|
+| Can the stage be cut whole? *The only thing that can force A.* | `parse_pubmed_into_tsvs` and `conflate_synonyms` are stdlib-only, paths in and paths out — zero entanglement. The entanglement is all in `write_compendium`. |
+| Build burden on people who write no Rust | **B/C.** `[tool.uv] package = true` + maturin means *every* `uv sync` needs cargo — for contributors touching no Rust, for the Docker image, for CI lint jobs. A structurally cannot avoid this; B/C makes `cargo build` optional. |
+| Differential testing | **B/C.** This document requires "Python is the specification, a test proves Rust matches it". Out-of-process that test is `diff` on two files, which also covers serialization. In-process it is a Python-object equality harness with `frozenset` ordering hazards. |
+| Observability | **B/C** — but note the coupling: a `benchmark:` TSV comes from a separate *rule*, not a separate *process*, so you only get it by paying for an intermediate file. Observability and boundary cost are the same decision. |
+| Memory accounting under SLURM | **B/C.** Two sequenced peaks, independently reserved, versus one peak that is the sum. Chemicals, split, peaks at 132 GB then 335 GB; protein, unsplit, peaks at 246 GB in one reservation. |
+| Reversibility | **B/C** — delete a binary, restore one `shell:` line. And this has a deadline: `rust/src/lib.rs` currently exports one constant and **zero functions**, so reverting today costs only a build-backend swap. That stops being true with the first real `#[pyfunction]`. |
+| Who can reproduce a bug | **B/C** — a binary runs by hand against a file path; a `#[pyfunction]` is only reachable through a multi-hour Snakemake rule. |
+| Failure isolation | **Neither, materially.** Every rule is already its own SLURM job (`slurm/config.yaml`, `jobs: 50`) and Snakemake retries a failed `run:` and a failed `shell:` identically. Do not lean on this. |
+
+### Recommendation (not a decision)
+
+**Default to B or C. Keep A for the case where Rust must sit inside a Python function that cannot be
+split** — realistically only `write_compendium`, and only if profiling shows Rust would help there
+at all. Keep #975's plumbing: it is the mechanism for the A case, it is already built and reviewed,
+and its marginal cost is the toolchain requirement.
+
+### The strongest argument against this recommendation
+
+**Every new rule boundary is a new serialization format, and a format is a public interface that
+needs versioning.** A new intermediate file has to be named, placed, made `temp()` or not, sized
+into the disk budget — and then kept compatible across changes on both sides. Babel already has one
+of these that nobody designed: `f"{set(s)}\n"` written at `chemicals.py:1110-1113` and read back
+with `ast.literal_eval` at `:1165-1168`, a Python `repr` serving as a wire format. Adding *N* more
+Rust-writes/Python-reads contracts is *N* more places for silent format drift. By contrast the pyo3
+boundary is a function signature, covered by `src/_accel.pyi` and the `ABI_VERSION` guard.
+
+Mitigation if B/C is chosen: **mandate JSONL for new boundaries and nothing else**, and rely on the
+`diff`-based differential test to catch drift on the first CI run. The cost is real either way.
+
+## The FFI boundary rule (if A is used)
+
+A `#[pyfunction]` takes a **file path** and returns the whole parsed result. It never takes one row.
+Crossing pyo3 once per CURIE costs more than the Python it replaces, so a per-row entry point would
+be *slower* while looking like an optimisation. Enforced structurally: Rust functions open their own
+files, so no entry point could accept a row.
+
+Note the tension this creates, because it is the crux of the whole question: taken seriously, this
+rule means every Rust entry point is already shaped like a standalone program. **The discipline that
+makes pyo3 fast is the discipline that makes pyo3 unnecessary.**
+
+## Using the in-process extension
 
 Import through [`src/accel.py`](../src/accel.py), never `src._accel` directly:
 
@@ -54,86 +178,71 @@ def read_something(path):
     return _read_something_python(path)
 ```
 
-`accel` is the compiled module when it is present, importable and current, and `None` otherwise.
-
-**A missing extension falls back to Python rather than raising.** Every snakefile does a top-level
-`import src.foo` at DAG-parse time, so an `ImportError` would take down all 245 rules for a
-contributor without a Rust toolchain, for a reviewer, and for a fork's CI — not just the rules that
-would have used Rust. AGENTS.md's "a log warning is not a control" is about *wrong output*; a slower
-path producing identical bytes is not that. The active implementation is logged once at INFO, which
-lands in the SLURM job log that `babel-slurm-errors` reads.
-
-**`BABEL_DISABLE_RUST=1` forces the Python path**, which is how you A/B a port in one checkout. It
-is an environment variable rather than a `config.yaml` entry deliberately: which of two
-byte-identical implementations runs is an implementation detail with no user-facing meaning, and
-`config.yaml` is threaded into Snakemake `params` and output paths, where changing it risks
-perturbing the DAG of a running build. Precedent: `BABEL_DUCKDB_TEMP_DIR`.
-
-## Staleness
-
-The extension is installed **editable**: the compiled artifact lands in the checkout at
-`src/_accel.*.so` (gitignored), and that is the copy `PYTHONPATH=.` finds. A `git pull` that brings
-new Rust source does **not** rebuild it, so without a guard a stale binary would be used silently
-— potentially for a 12-hour rule.
-
-So `src/accel.py` compares the extension's `ABI_VERSION` against its own `_REQUIRED_ABI_VERSION`
-and raises if they disagree. The check runs at import, i.e. at DAG-parse time, so a stale build
-fails in the first second of a run. To fix one:
-
-```bash
-uv sync --reinstall-package babel-pipeline
-```
-
-What the guard does not catch is editing the Rust body without bumping the constant. That is what
-the differential tests are for — they compare against the Python reference regardless of where the
-`.so` came from, which also covers a `.so` served from a stale uv or cargo cache in CI.
+- **A missing extension falls back to Python rather than raising.** Every snakefile does a top-level
+  `import src.foo` at DAG-parse time, so an `ImportError` would take down all 243 rules for a
+  contributor without a toolchain, a reviewer, or a fork's CI. AGENTS.md's "a log warning is not a
+  control" is about *wrong output*; a slower path producing identical bytes is not that.
+- **A stale extension raises.** The extension is installed editable, so the compiled artifact lives
+  in the checkout at `src/_accel.*.so` and `git pull` does not rebuild it. `ABI_VERSION` is compared
+  at import — i.e. at DAG-parse time — so a stale build fails in the first second rather than eleven
+  hours into a rule. Fix with `uv sync --reinstall-package babel-pipeline`.
+- **`BABEL_DISABLE_RUST=1` forces the Python path**, which is how you A/B a port in one checkout. An
+  environment variable rather than a `config.yaml` entry: which of two byte-identical
+  implementations runs has no user-facing meaning, and `config.yaml` is threaded into Snakemake
+  `params` and output paths where changing it could perturb a running DAG. Precedent:
+  `BABEL_DUCKDB_TEMP_DIR`.
+- **Keep the Python implementation as the reference**, with a test asserting the two produce
+  identical output. The Python is the specification; the test is the proof. Bump `ABI_VERSION` in
+  both `rust/src/lib.rs` and `src/accel.py` in the same commit as any semantic change.
 
 ## Building
 
-A Rust toolchain is a build prerequisite for **every** environment now, because `[tool.uv] package
-= true` means every `uv run` and `uv sync` builds the project, and building the project invokes
-cargo.
+A toolchain is a build prerequisite for **every** environment, because `[tool.uv] package = true`
+means every `uv run` and `uv sync` builds the project, and building it invokes cargo.
 
-- **Locally:** `uv sync`. If `cargo` is not on `$PATH`, uv bootstraps a toolchain itself (via
-  `puccinialin`) rather than failing — convenient, but it silently downloads ~600 MB into a
-  platform cache directory that `UV_CACHE_DIR` does **not** cover. Installing rustup yourself
-  (`brew install rustup && rustup default stable`, or <https://rustup.rs>) avoids that.
+- **Locally:** `uv sync`. Without `cargo` on `$PATH`, uv bootstraps a toolchain itself (via
+  `puccinialin`) rather than failing — convenient, but it silently downloads ~600 MB into a platform
+  cache directory that `UV_CACHE_DIR` does **not** cover. `brew install rustup && rustup default
+  stable` (or <https://rustup.rs>) avoids that.
 - **CI:** `dtolnay/rust-toolchain@stable` plus `Swatinem/rust-cache@v2` in `test.yml`. The
-  formatting workflow deliberately runs snakefmt with `uv run --no-project` so that a lint job does
-  not build the project at all.
-- **Docker:** the image installs rustup rather than `apt install cargo`. Debian bookworm ships
-  cargo 1.63, which is *exactly* pyo3 0.23's minimum, so the next pyo3 bump would break the image
-  with an error that reads as unrelated. rustup also honours `rust-toolchain.toml`, which apt's
-  cargo ignores.
+  formatting workflow runs snakefmt with `uv run --no-project` so a lint job does not build at all.
+- **Docker:** rustup, not `apt install cargo` — Debian bookworm ships cargo 1.63, *exactly* pyo3
+  0.23's minimum, so the next pyo3 bump would break the image with an unrelated-looking error.
+  rustup also honours `rust-toolchain.toml`, which apt's cargo ignores.
 - **Hatteras:** `uv sync` runs once on the login node and compute nodes reuse the `.venv` from
-  `/projects`, so compilation happens in one place. Make sure a toolchain is available there before
-  a build — `uv sync --frozen` fails outright without one, before Snakemake starts. See
-  [`slurm/README.md`](../slurm/README.md).
+  `/projects`, so compilation happens in one place — but `uv sync --frozen` **fails outright**
+  without a toolchain, before Snakemake starts. See [`slurm/README.md`](../slurm/README.md).
 
-`rust-toolchain.toml` pins the channel (`stable`) rather than an exact version: nothing here
-publishes a wheel, so the value of pinning is that everyone's cargo comes from the same place
-rather than from whatever a distro packages. The hard floor is `rust-version` in `rust/Cargo.toml`.
+`rust-toolchain.toml` pins the channel (`stable`) rather than a version: nothing publishes a wheel,
+so the value is that everyone's cargo comes from the same place. The hard floor is `rust-version` in
+`rust/Cargo.toml`.
 
 ## Layout
 
 | Path | What |
 |------|------|
-| `rust/Cargo.toml` | the crate. `version` is `0.0.0` on purpose — maturin takes the distribution version from the root `pyproject.toml`, and nothing publishes this crate |
+| `rust/Cargo.toml` | the crate. `version = "0.0.0"` on purpose — maturin takes the distribution version from the root `pyproject.toml`, and nothing publishes this crate |
 | `rust/src/lib.rs` | the `#[pymodule]`: module doc, `ABI_VERSION`, registrations. Functions go in their own modules, split from the first one |
 | `src/accel.py` | the only thing that imports the compiled module |
-| `src/_accel.pyi` | hand-written stub. There is no mypy here, so it enforces nothing; it exists so a reader who does not read Rust can see what the module offers |
-| `rust-toolchain.toml` | channel pin |
+| `src/_accel.pyi` | hand-written stub. No mypy here, so it enforces nothing; it exists so a reader who does not read Rust can see what the module offers |
+| `docs/rust-decision/` | the boundary-cost experiment behind the recommendation above |
 
-## History
+## History, and a correction
 
-[PR #588](https://github.com/NCATSTranslator/Babel/pull/588) took a different approach — 19
-standalone binaries under `babel_io/src/bin/` invoked from Snakemake `shell:` blocks — and is worth
-reading as a cautionary tale. It targeted datacollect label/synonym rules totalling roughly 1.5 h of
-CPU, under 2% of the pipeline, two of them download-bound where Rust does nothing; the one binary
-aimed at an expensive rule (`build_compendia.rs`) is a 72-line stub. 3,252 lines across 44 files,
-unmerged. Hence the "measure first" and "one path, deep" rules above.
+[PR #588](https://github.com/NCATSTranslator/Babel/pull/588) built 19 standalone binaries under
+`babel_io/src/bin/` invoked from `shell:` blocks. 3,252 lines across 44 files, unmerged since
+September 2025. Its failure was **targeting**: those binaries covered datacollect label/synonym
+rules totalling roughly 1.5 h of CPU — under 2% of the pipeline — two of them download-bound where
+Rust does nothing, while `build_compendia.rs`, the one aimed at an expensive rule, is a 72-line
+stub.
 
-The in-process pyo3 model that replaced it fits the codebase better regardless: 245 of Babel's
-Snakemake rules are `run:` blocks with no `script:` directives and no subprocess boundaries, so an
-importable extension needs no rule rewriting, whereas standalone binaries would mean converting
-rules to `shell:` one at a time.
+An earlier AI-written version of this file drew the wrong lesson from that, concluding "the
+in-process model fits the codebase better" and supporting it with "245 of Babel's Snakemake rules
+are `run:` blocks with no `script:` directives and no subprocess boundaries."
+**Both halves were wrong.** The counts are **243 `run:` and 26 `shell:`**, and
+`reports.snakefile:209-213` already threads config-derived roots into a console script — the exact
+pattern that paragraph claimed did not exist.
+
+## 588's lesson is about picking targets, not about which shape to use; that is why "Rule 0" above
+
+leads this document.

--- a/docs/rust-decision/README.md
+++ b/docs/rust-decision/README.md
@@ -1,0 +1,107 @@
+# Does an in-process Rust boundary buy anything? — measured
+
+> **This is an AI-written experiment. No human has reviewed it yet, and no decision has been
+> taken.** See [`../Rust.md`](../Rust.md) for the framing and the recommendation it feeds.
+
+## What was measured, and why not pyo3 directly
+
+Rust can enter Babel two ways: **in-process** (a pyo3 extension,
+[PR #975](https://github.com/NCATSTranslator/Babel/pull/975)) or **out-of-process** (a separate
+program invoked from a Snakemake `shell:` rule, handing data over through a file). Out-of-process is
+cheaper on nearly every axis — no toolchain for people who write no Rust, its own `benchmark:` TSV,
+its own SLURM reservation, `diff` as the differential test, revertible by editing one rule. The one
+axis where in-process could win is the cost of getting data across.
+
+Benchmarking a pyo3 arm directly would not settle anything: it has no single honest shape (return a
+list of tuples? an iterator? a `#[pyclass]`?), so any number invites "you picked the wrong return
+type". So [`boundary_cost.py`](./boundary_cost.py) measures a **floor** that no pyo3 implementation
+can beat:
+
+> **F** = the cost of constructing the Python objects the consumer needs, from raw bytes.
+
+Anything that ends with Python holding the data pays at least F. Therefore
+**max possible saving from in-process = cost(file arm) − F**, and pyo3 is credited here with a
+serialization cost of exactly *zero*. If that gap is small next to the rule it sits inside, no Rust
+implementation can rescue it.
+
+## Result
+
+Payload: the anatomy clique state read straight out of `babel_outputs/compendia/*.txt` (178,870
+cliques, 306,924 members — a finished compendium line *is* a clique), replicated to multiply
+cardinality while preserving clique-size and string-length distributions. Every arm ends holding
+`set[frozenset[str]]`, which is what all 14 of `glom()`'s consumers build. All arms were asserted to
+produce an identical clique set before any timing was believed.
+
+```text
+=== scale 10x — 1,788,700 cliques, 3,069,240 members ===
+arm         produce_s  consume_s   total_s   file_MB  peak_GB
+floor            0.00       1.93      1.93       0.0     1.03
+repr_set         1.30      10.50     11.80      53.4     1.01
+jsonl            2.07       2.93      5.00      53.4     1.04
+parquet          0.74       3.55      4.29      29.9     1.79
+```
+
+`repr_set` is not a straw man: `f"{set(s)}\n"` written at `chemicals.py:1110-1113` and read back
+with `ast.literal_eval` at `:1165-1168` is the **actual** format of the boundary between
+`untyped_chemical_compendia` and `chemical_compendia` today — a Python `repr` used as a wire format
+for the largest clique state in Babel.
+
+### Extrapolated to production scale
+
+`reports/tables/cliques_table.csv` from `babel-1.18` puts the chemical pipeline at **256,427,006
+CURIEs**, i.e. 83.5× the 10× payload. Against `chemical_compendia`'s measured 19,643 s:
+
+| Boundary | Extrapolated | Share of the rule |
+|---|---|---|
+| floor F (unavoidable) | 161 s | 0.8% |
+| JSONL round trip | 418 s | 2.1% |
+| Parquet round trip | 358 s | 1.8% |
+| `repr(set)` round trip (**status quo**) | 985 s | 5.0% |
+
+**Two conclusions:**
+
+1. **The maximum possible saving from going in-process is ~256 s — about 4 minutes, or 1.3% of a
+   5.5-hour rule.** That is the ceiling, granted to pyo3 for free. No pyo3 implementation can do
+   better, so the boundary cost cannot justify in-process on its own.
+2. **Switching the existing boundary from `repr(set)` to JSONL would save ~568 s — about 9.5
+   minutes, 2.2× more than in-process pyo3 could ever save** — and needs no Rust, no toolchain and
+   no FFI. The serialization *format* matters more than the mechanism.
+
+Per the interpretation pre-registered in the harness docstring before the first run: the file arms
+did **not** all land within 20% of each other, so this is partly a finding about format choice; and
+the gap to F, while a large *fraction* of each arm, is a rounding error against the rule it lives
+inside. The decision therefore falls to the non-performance criteria in [`../Rust.md`](../Rust.md).
+
+Note also that **F grows faster than the file arms** (1×→10×: floor 16×, JSONL 11.6×, Parquet 6.0×).
+Python object construction is the term that scales worst, so at larger payloads the relative
+advantage of in-process shrinks further rather than growing.
+
+## Reproduce
+
+```bash
+PYTHONPATH=. uv run python docs/rust-decision/boundary_cost.py --scale 1 --scale 10
+```
+
+Needs a local build's `babel_outputs/compendia/*.txt` — the anatomy target alone is enough
+(~25 minutes on a laptop, per `docs/RunningBabel.md`). Each arm runs in a fresh subprocess so peak
+RSS is per arm.
+
+## What this does not establish
+
+- **100× was not run.** It needs ~37M member CURIEs (~10-15 GB resident, ~1.5 GB of files) and the
+  machine this ran on has 16 GB RAM and 20 GB free. `--scale 100` should be run on a larger machine
+  or an HPC node before the extrapolation above is trusted. It would falsify this write-up if the
+  arms stopped scaling near-linearly — for instance if Python-object construction hit an allocator
+  cliff the file arms did not.
+- **The extrapolation is a per-item cost model, not a measurement at scale.** It should be checked
+  against a `py-spy` profile of a real `chemical_compendia` run: if the fraction of samples inside
+  `ast.literal_eval` disagrees with the 5.0% predicted above, believe the profile and discard this.
+- **I/O is served from page cache here.** A 53 MB file written and immediately reread on a laptop
+  SSD measures `memcpy`, not a parallel filesystem. The real I/O term is already recorded in the
+  benchmark TSVs (`untyped_chemical_compendia`: `io_out` 13,716 MB; `chemical_compendia`: `io_in`
+  36,762 MB) and is not modelled here.
+- **The one thing pyo3 can do that a file cannot** is never materialise into Python at all — Rust
+  keeps ownership and Python iterates lazily via a `#[pyclass]`. That escapes the floor entirely.
+  Its out-of-process equivalent is "port the consumer too", so it is a question about how far a
+  rewrite goes rather than about which mechanism is faster. This harness deliberately says nothing
+  about it, and it is the one argument for in-process that survives these numbers.

--- a/docs/rust-decision/boundary_cost.py
+++ b/docs/rust-decision/boundary_cost.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Measure what an in-process Rust boundary could possibly save over a file boundary.
+
+THE QUESTION. Babel's expensive rules are CPU-bound single-threaded Python. If some are
+reimplemented in Rust, the Rust can either live in-process (a pyo3 extension, PR #975) or in a
+separate process that hands data over through a file (a Snakemake `shell:` stage). The second is
+cheaper on almost every axis -- no toolchain for people who don't write Rust, its own `benchmark:`
+TSV, its own SLURM memory reservation, `diff` as the differential test, revertible by editing one
+rule. The one axis where in-process could win is the cost of getting the data across.
+
+WHY THIS DOES NOT BENCHMARK pyo3. A pyo3 arm has no single honest shape -- return a list of tuples,
+a list of lists, an iterator, a `#[pyclass]` handle? -- so any number is answerable with "you picked
+the wrong return type". Instead this measures a FLOOR that no pyo3 implementation can beat:
+
+    F = the cost of constructing the Python objects the consumer needs, from raw bytes.
+
+Any mechanism that ends with Python holding the data pays at least F. So:
+
+    maximum possible saving from going in-process  =  cost(file arm) - F
+
+If that gap is small next to the rule it sits inside, no Rust implementation can rescue it and the
+in-process case is closed -- without writing any Rust, and without handicapping pyo3, which is here
+credited with a serialization cost of exactly zero.
+
+WHAT IT CANNOT DECIDE. The one thing pyo3 can do that a file cannot is never materialise into
+Python at all: Rust keeps ownership and Python iterates lazily through a `#[pyclass]`. That is a
+real capability, but its out-of-process equivalent is "port the consumer too", so it is a question
+about how far a rewrite goes, not about which mechanism is faster. This harness deliberately does
+not speak to it.
+
+PRE-REGISTERED INTERPRETATION -- written before the first run, so the result cannot be read
+backwards into whichever conclusion is convenient:
+
+  * If the file arms land within ~20% of each other AND close to F, the finding is "the mechanism
+    is irrelevant given this consumer" -- NOT "pyo3 is worthless". The decision then falls to the
+    non-performance criteria in docs/Rust.md.
+  * If a file arm is several times F, in-process has a real prize and the pyo3 case is open.
+  * If the arms disagree with each other by a lot, the finding is about serialization format
+    choice, which is worth acting on independently of Rust.
+
+Usage:
+    PYTHONPATH=. uv run python docs/rust-decision/boundary_cost.py --scale 1 --scale 10
+
+Requires a local build's compendia under babel_outputs/compendia/*.txt. Peak RSS is per arm,
+measured in a fresh subprocess, so arms cannot inflate each other.
+"""
+
+import argparse
+import ast
+import hashlib
+import json
+import os
+import resource
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+COMPENDIA = REPO / "babel_outputs/compendia"
+SCRATCH = REPO / "data/scratch/boundary_cost"
+
+# Arms. Every one ends with Python holding `set[frozenset[str]]`, which is what all 14 of glom's
+# consumers build (`set(frozenset(x) for x in dicts.values())`).
+ARMS = ("floor", "repr_set", "jsonl", "parquet")
+
+
+def fingerprint(cliques):
+    """A stable, order-independent digest of a clique set, comparable across processes."""
+    digest = hashlib.sha256()
+    for clique in sorted("\t".join(sorted(c)) for c in cliques):
+        digest.update(clique.encode())
+        digest.update(b"\n")
+    return digest.hexdigest()[:16]
+
+
+def peak_rss_gb():
+    """Peak RSS of this process. ru_maxrss is bytes on macOS, kilobytes on Linux."""
+    maxrss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return maxrss / 1024**3 if sys.platform == "darwin" else maxrss / 1024**2
+
+
+def load_cliques(scale):
+    """Read cliques out of a finished build's compendia, replicated `scale` times.
+
+    Each compendium line is one clique, and its `identifiers[].i` values are its members -- so the
+    finished compendia already hold exactly the clique state glom produces, with no pipeline run
+    needed. Replication suffixes every CURIE with a replica index, which multiplies cardinality
+    while preserving the string-length and clique-size distributions that drive the costs here.
+
+    Returned as lists of `bytes`, not `str`, deliberately: see the note in `arm_floor`.
+    """
+    base = []
+    for path in sorted(COMPENDIA.glob("*.txt")):
+        with open(path) as handle:
+            for line in handle:
+                base.append([identifier["i"] for identifier in json.loads(line)["identifiers"]])
+    # Every scale suffixes, including 1x: otherwise 1x holds shorter, more interning-prone strings
+    # than 10x and the two points are not comparable, which would make the scaling look superlinear
+    # for reasons that have nothing to do with the boundary.
+    return [[f"{curie}~{replica}".encode() for curie in clique] for replica in range(scale) for clique in base]
+
+
+# ARMS
+
+
+def arm_floor(cliques, _path):
+    """The floor: no serialization at all, just build the Python objects from bytes.
+
+    `.decode()` on each member is what makes this honest. Timing `[frozenset(c) for c in cliques]`
+    over data that already holds `str` objects would only bump refcounts -- it would measure
+    almost nothing, make every file arm look catastrophic by comparison, and "prove" that pyo3
+    wins by a mile. Fresh string construction is the term both arms genuinely share, so it has to
+    be inside the floor.
+    """
+    return 0.0, lambda: {frozenset(member.decode() for member in clique) for clique in cliques}
+
+
+def arm_repr_set(cliques, path):
+    """The status quo boundary: `f"{set(s)}\\n"` read back with `ast.literal_eval`.
+
+    Not a straw man -- this is what `chemicals.py:1110-1113` writes and `:1165-1168` reads back
+    between `untyped_chemical_compendia` and `chemical_compendia` today, i.e. a Python `repr` used
+    as a wire format for the largest clique state in Babel.
+    """
+
+    def produce():
+        with open(path, "w") as out:
+            for clique in cliques:
+                out.write(f"{ {member.decode() for member in clique} }\n")
+
+    def consume():
+        with open(path) as handle:
+            return {frozenset(ast.literal_eval(line)) for line in handle}
+
+    return produce, consume
+
+
+def arm_jsonl(cliques, path):
+    """JSONL: one JSON array of members per line. The format a new boundary should use."""
+
+    def produce():
+        with open(path, "w") as out:
+            for clique in cliques:
+                out.write(json.dumps([member.decode() for member in clique]) + "\n")
+
+    def consume():
+        with open(path) as handle:
+            return {frozenset(json.loads(line)) for line in handle}
+
+    return produce, consume
+
+
+def arm_parquet(cliques, path):
+    """Parquet via DuckDB: already a dependency, and already how Babel writes its exports.
+
+    Stored long -- one row per (clique_index, member) -- because that is the natural columnar
+    shape and avoids depending on DuckDB's LIST round-tripping.
+    """
+    import duckdb
+
+    def produce():
+        tsv = path.with_suffix(".staging.tsv")
+        with open(tsv, "w") as out:
+            for index, clique in enumerate(cliques):
+                for member in clique:
+                    out.write(f"{index}\t{member.decode()}\n")
+        con = duckdb.connect()
+        # Paths are interpolated, not bound: DuckDB does not accept a parameter as a COPY target.
+        # Both are harness-controlled paths under data/scratch, not user input.
+        con.execute(
+            f"COPY (SELECT * FROM read_csv('{tsv}', delim='\t', header=false, "
+            "columns={'clique': 'INTEGER', 'curie': 'VARCHAR'})) "
+            f"TO '{path}' (FORMAT PARQUET)"
+        )
+        con.close()
+        tsv.unlink()
+
+    def consume():
+        con = duckdb.connect()
+        rows = con.execute("SELECT clique, curie FROM read_parquet(?) ORDER BY clique", [str(path)]).fetchall()
+        con.close()
+        grouped = {}
+        for clique_index, curie in rows:
+            grouped.setdefault(clique_index, []).append(curie)
+        return {frozenset(members) for members in grouped.values()}
+
+    return produce, consume
+
+
+ARM_FUNCTIONS = {"floor": arm_floor, "repr_set": arm_repr_set, "jsonl": arm_jsonl, "parquet": arm_parquet}
+
+
+def run_arm(arm, scale):
+    """Run one arm in this process and print a JSON result line."""
+    SCRATCH.mkdir(parents=True, exist_ok=True)
+    path = SCRATCH / f"{arm}_{scale}x.data"
+
+    cliques = load_cliques(scale)
+    members = sum(len(clique) for clique in cliques)
+
+    produce, consume = ARM_FUNCTIONS[arm](cliques, path)
+
+    if callable(produce):
+        start = time.perf_counter()
+        produce()
+        # fsync so the write cost is not deferred past the timer.
+        with open(path, "rb") as handle:
+            os.fsync(handle.fileno())
+        produce_seconds = time.perf_counter() - start
+        file_mb = path.stat().st_size / 1024**2
+    else:
+        produce_seconds, file_mb = 0.0, 0.0
+
+    start = time.perf_counter()
+    result = consume()
+    consume_seconds = time.perf_counter() - start
+
+    print(
+        json.dumps(
+            {
+                "arm": arm,
+                "scale": scale,
+                "cliques": len(cliques),
+                "members": members,
+                "produce_s": produce_seconds,
+                "consume_s": consume_seconds,
+                "file_mb": file_mb,
+                "peak_rss_gb": peak_rss_gb(),
+                # Order-independent fingerprint so the parent can assert every arm agreed without
+                # shipping the whole clique set between processes. hashlib, not hash(): Python
+                # salts str hashing per process, so hash() would differ for identical content and
+                # every comparison would spuriously fail.
+                "fingerprint": fingerprint(result),
+            }
+        )
+    )
+    if path.exists():
+        path.unlink()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--scale", type=int, action="append", help="replication factor; repeatable")
+    parser.add_argument("--arm", choices=ARMS, help="internal: run a single arm and print JSON")
+    parser.add_argument("--only", choices=ARMS, action="append", help="restrict to these arms")
+    args = parser.parse_args()
+
+    if args.arm:
+        run_arm(args.arm, args.scale[0])
+        return
+
+    scales = args.scale or [1]
+    arms = args.only or list(ARMS)
+
+    for scale in scales:
+        results = {}
+        for arm in arms:
+            completed = subprocess.run(
+                [sys.executable, __file__, "--arm", arm, "--scale", str(scale)],
+                capture_output=True,
+                text=True,
+                cwd=REPO,
+            )
+            if completed.returncode != 0:
+                print(f"  {arm}: FAILED\n{completed.stderr[-2000:]}", file=sys.stderr)
+                continue
+            results[arm] = json.loads(completed.stdout.strip().splitlines()[-1])
+
+        if not results:
+            continue
+        first = next(iter(results.values()))
+        print(f"\n=== scale {scale}x — {first['cliques']:,} cliques, {first['members']:,} members ===")
+        print(f"{'arm':<10} {'produce_s':>10} {'consume_s':>10} {'total_s':>9} {'file_MB':>9} {'peak_GB':>8}")
+        for arm in arms:
+            r = results.get(arm)
+            if not r:
+                continue
+            total = r["produce_s"] + r["consume_s"]
+            print(
+                f"{arm:<10} {r['produce_s']:>10.2f} {r['consume_s']:>10.2f} {total:>9.2f} "
+                f"{r['file_mb']:>9.1f} {r['peak_rss_gb']:>8.2f}"
+            )
+
+        fingerprints = {arm: r["fingerprint"] for arm, r in results.items()}
+        if len(set(fingerprints.values())) != 1:
+            print(f"  MISMATCH — arms disagree on the clique set: {fingerprints}", file=sys.stderr)
+            raise SystemExit("arms produced different results; timings are meaningless")
+        print("  all arms produced an identical clique set")
+
+        if "floor" in results:
+            floor = results["floor"]["consume_s"]
+            print(f"\n  floor F (Python object construction, unavoidable): {floor:.2f} s")
+            for arm in arms:
+                if arm == "floor" or arm not in results:
+                    continue
+                total = results[arm]["produce_s"] + results[arm]["consume_s"]
+                print(
+                    f"  max possible saving from in-process vs {arm:<9}: {total - floor:6.2f} s "
+                    f"({(total - floor) / total * 100:4.1f}% of that arm)"
+                )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
> ## ⚠️ AI-written experiment. Not reviewed by a human. Not a decision.
>
> Everything in this PR was written by Claude (Claude Code) at @gaurav's request. **No human has
> reviewed it yet**, including @gaurav, and **no decision has been taken**. Please read the
> recommendation as one input, not as an outcome.
>
> **The question it exists to answer:** #975 makes in-process pyo3 the way Rust enters Babel. Nothing
> had established that in-process is what Rust here actually needs. So: *where in Babel would Rust
> help, and how should it be wired in?*
>
> **The options being compared** (`docs/Rust.md` → "How to integrate"):
>
> | | Shape | Boundary |
> |---|---|---|
> | **A** | in-process pyo3, one package — **what #975 builds** | Python objects across FFI |
> | **B** | standalone program invoked from a Snakemake `shell:` rule | a file, at an existing rule edge |
> | **C** | split a rule at a *new* file boundary, implement one side in Rust | a file, at a new rule edge |
> | **D** | no Rust — DuckDB and other native libraries already in the tree | prebuilt wheel |
>
> **The recommendation is B/C by default, keeping A for the one case that needs it.** #975 currently
> implies A. That disagreement is the point of the PR and is for @gaurav and @SkyeAv to settle.
>
> This PR **does not touch #975's code** and does not ask for it to be reverted. It builds on top of
> it, keeps its plumbing, and only rewrites `docs/Rust.md` — a file an earlier AI pass wrote, whose
> two central factual claims turned out to be wrong (see below). That is itself a reason to check
> this document rather than trust it.

## What this adds

- **`docs/rust-decision/boundary_cost.py`** — the experiment, plus
  **`docs/rust-decision/README.md`** with its results and caveats.
- **`docs/Rust.md`** rewritten: where Rust would help, where it would not, the four shapes, the
  criteria that carry the decision, and the strongest argument *against* the recommendation.

No `src/` changes. No Rust code. Nothing in the pipeline behaves differently.

## The experiment, and why it does not benchmark pyo3

A pyo3 arm has no single honest shape — return a list of tuples? an iterator? a `#[pyclass]`? — so
any number invites *"you picked the wrong return type."* Instead the harness measures a **floor** no
pyo3 implementation can beat:

> **F** = the cost of constructing the Python objects the consumer needs, from raw bytes.

Anything that ends with Python holding the data pays at least F, so
**max possible saving from in-process = cost(file arm) − F**, with pyo3 credited a serialization cost
of exactly **zero**.

Payload: the anatomy clique state read straight out of a finished build's compendia (178,870 cliques
— a compendium line *is* a clique), replicated to multiply cardinality. Every arm ends holding
`set[frozenset[str]]`, what all 14 of `glom()`'s consumers build, and all arms were asserted to
produce an identical clique set before any timing was believed.

```text
=== scale 10x — 1,788,700 cliques, 3,069,240 members ===
arm         produce_s  consume_s   total_s   file_MB  peak_GB
floor            0.00       1.93      1.93       0.0     1.03
repr_set         1.30      10.50     11.80      53.4     1.01
jsonl            2.07       2.93      5.00      53.4     1.04
parquet          0.74       3.55      4.29      29.9     1.79
```

`repr_set` is not a straw man — `f"{set(s)}\n"` + `ast.literal_eval` is the *actual* format of the
boundary between `untyped_chemical_compendia` and `chemical_compendia` today.

## Result

Extrapolated to the chemical pipeline's **256,427,006 CURIEs** (`babel-1.18`'s
`reports/tables/cliques_table.csv`) against `chemical_compendia`'s measured **19,643 s**:

1. **The ceiling on what in-process could save is ~4 minutes — 1.3% of a 5.5-hour rule.** No pyo3
   implementation can do better, so boundary cost cannot justify in-process on its own.
2. **Switching the existing `repr(set)` boundary to JSONL would save ~9.5 minutes — 2.2× more than
   in-process could ever save**, with no Rust, no toolchain and no FFI. The serialization *format*
   matters more than the mechanism.

The floor also grows *faster* than the file arms across scales, so the relative case for in-process
shrinks at larger payloads rather than growing.

## Where Rust would help, and where it would not

- **Best case: `glom()`'s union-find.** The win is memory, not speed — glom holds clique state as
  Python objects at **73 MB resident for something that serialises to 4.8 MB (15×)**, which is why
  `protein_compendia` and `chemical_compendia` sit at 246 GB and 335 GB behind `mem="512G"`.
- **Not `generate_pubmed_concords`**, despite being the biggest number (20 h). It parses ~1,500
  *independent* files at one core — a sharding refactor, and @gaurav's DuckDB effort would supersede
  it anyway.
- **Profile `write_compendium` with `py-spy` before porting it.** Two uninvestigated defects sit in
  its setup: `get_biolink_model_toolkit` has no cache and refetches + reparses the Biolink YAML from
  GitHub on every call, and `InformationContentFactory` re-reads all 3,940,399 lines of the 212 MB
  `icRDF.tsv` calling `curies.compress()` per line — both **8 times** per chemical build.

## Two corrections to the earlier `docs/Rust.md`

Both were asserted by an earlier AI pass without checking, and both are load-bearing for the
conclusion that file was drawing:

- Rule counts are **243 `run:` and 26 `shell:`**, not "245 `run:` with no subprocess boundaries".
- **`reports.snakefile:209-213` already invokes a console script from `shell:`** with config-derived
  roots threaded in as `params:` — the exact pattern that paragraph claimed did not exist, and the
  precedent for how an out-of-process stage learns where its files are.

## What is not established

- **100× was not run.** It needs ~37M CURIEs; this ran on a 16 GB machine with 20 GB free. It should
  be repeated on a larger machine or an HPC node —
  `--scale 100` — and `docs/rust-decision/README.md` says what would falsify the write-up.
- The extrapolation is a per-item cost model, not a measurement at scale. It should be checked
  against a `py-spy` profile of a real run; if they disagree, believe the profile.
- I/O here is served from page cache, so it is not modelled; the real term is in the benchmark TSVs.
- **The one argument for in-process that survives these numbers** is the case where Rust keeps
  ownership and Python never materialises the data at all (a `#[pyclass]` iterated lazily). That
  escapes the floor entirely. Its out-of-process equivalent is "port the consumer too", so it is a
  question about how far a rewrite goes — and this experiment deliberately says nothing about it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
