### PR TITLE
Correct where babel-slurm-resources gets its wall times, and what a retry does to them

### DIFF
--- a/docs/tools/Resources.md
+++ b/docs/tools/Resources.md
@@ -39,8 +39,11 @@ A Snakemake-on-SLURM run leaves three kinds of artifact under `babel_outputs/`:
   usually holds just a handful of rules. The reader therefore merges *all* shards (worst case per
   rule); reading only the newest would drop the requested-side data for almost every rule. When
   archiving a run, copy the whole directory, not just the newest file.
-- `logs/rule_<name>/<jobid>.log` — per-rule control-node logs: the declared `resources:` line and
-  start/end timestamps, used as a fallback for the requested side and for the runtime limit.
+- `logs/rule_<name>/<jobid>.log` — per-rule control-node logs. What this subcommand reads out of
+  them is the declared `resources:` line, as a fallback for the requested side and as the first
+  choice for the runtime limit. The parser also records each job's start/end timestamps and whether
+  it failed, but the sizing report uses neither: **every** wall-time figure it prints comes from the
+  benchmarks.
 
 ### Why the benchmark TSVs, not the efficiency report
 
@@ -48,9 +51,15 @@ The efficiency report is the natural place to look for memory and CPU usage, but
 `MaxRSS` and `TotalCPU` columns come back **empty** — the cluster's `jobacct_gather`/cgroup
 accounting isn't capturing per-step usage, so every `CPU Efficiency (%)` and `Memory Usage (%)` is
 `0`. The tool therefore uses the efficiency report only for the *requested* side
-(`RequestedMem_MB`, `NCPUS`, elapsed wall time) and relies on the `benchmark:` TSVs for actual
-usage. Because the recommendations come from the benchmarks, the override list (below) is reliable
-even when the requested side is sparse.
+(`RequestedMem_MB` and `NCPUS` — those two columns and no others) and relies on the `benchmark:`
+TSVs for actual usage. Because the recommendations come from the benchmarks, the override list
+(below) is reliable even when the requested side is sparse.
+
+That includes wall time: **every duration in the report is the benchmark TSV's `s` column**
+(`Benchmark.seconds`, the per-column worst case across a rule's rows), never the efficiency
+report's `Elapsed_sec` or the span between a log's timestamps. Snakemake writes `s` from inside
+the job, so it measures execution and excludes SLURM queue time — the conservative choice for
+sizing a time limit, since the limit applies to execution too.
 
 ### Units
 

--- a/docs/tools/Resources.md
+++ b/docs/tools/Resources.md
@@ -39,10 +39,11 @@ A Snakemake-on-SLURM run leaves three kinds of artifact under `babel_outputs/`:
   usually holds just a handful of rules. The reader therefore merges *all* shards (worst case per
   rule); reading only the newest would drop the requested-side data for almost every rule. When
   archiving a run, copy the whole directory, not just the newest file.
-- `logs/rule_<name>/<jobid>.log` — per-rule control-node logs. What this subcommand reads out of
-  them is the declared `resources:` line, as a fallback for the requested side and as the first
-  choice for the runtime limit. The parser also records each job's start/end timestamps and whether
-  it failed, but the sizing report uses neither: **every** wall-time figure it prints comes from the
+- `logs/rule_<name>/<jobid>.log` — per-rule control-node logs. The only thing read out of them is
+  the declared `resources:` line, as a fallback for the requested side and as the first choice for
+  the runtime limit. A log also carries the job's own start/end timestamps and its failure state;
+  neither is parsed, and the comment above `RuleLog` in `src/tools/slurm/parse.py` says how to
+  extract them if you ever need to. **Every** wall-time figure in the report comes from the
   benchmarks.
 
 ### Why the benchmark TSVs, not the efficiency report
@@ -81,11 +82,18 @@ a median of 5s: the gap is job startup and teardown around the benchmarked body.
 `s` slightly *understates* the span the limit applies to. At the default `--safety 1.5` that is
 noise, but it is the reason not to trim a runtime to a hair above the benchmark.
 
-`Elapsed_sec` is parsed into `EfficiencyRow` and simply not used, which is deliberate: the column
-is reliable (unlike `MaxRSS`/`TotalCPU` on this cluster), and having it already parsed and
-documented is what a future "how long do jobs actually hold their allocation?" question needs. The
-same goes for `RuleLog.start`/`end`/`failed`. Nothing consumes them today; deleting them would
-throw away the part that took the work — knowing which artifact records which span.
+`Elapsed_sec` is parsed into `EfficiencyRow` and simply not used, which is deliberate: it is a
+named column read straight into a float, so it cannot quietly start meaning something else, and
+having it parsed and documented is what a future "how long do jobs hold their allocation?" question
+needs.
+
+The per-rule logs' start/end timestamps and failure state are the opposite case and are **not**
+parsed. Extracting those means matching free-form log text, which rots silently when Snakemake
+changes its output — and a test fixture cannot catch that, since it pins the format it was copied
+from rather than the one the cluster emits next year. The recipe for both lives in a comment above
+`RuleLog` in `src/tools/slurm/parse.py`, so re-deriving them is a few lines rather than an
+investigation. Prefer `parse_job_events()` anyway: the aggregate sbatch `.err` log names every
+attempt with its submit and finish timestamps in one place.
 
 ### Units
 

--- a/docs/tools/Resources.md
+++ b/docs/tools/Resources.md
@@ -87,6 +87,36 @@ named column read straight into a float, so it cannot quietly start meaning some
 having it parsed and documented is what a future "how long do jobs hold their allocation?" question
 needs.
 
+### What a retry, or a second run, does to each number
+
+A Babel build usually takes several `sbatch` runs to finish, and rules fail and are retried inside
+each one. The three clocks handle that differently, so a number is only comparable to another
+number of the same kind:
+
+- **Benchmarks: the last *successful* execution, and nothing else.** Snakemake rewrites
+  `benchmarks/<rule>.tsv` on each execution (all 355 files from the 2026jul22 build hold exactly
+  one row), and a failed job writes no benchmark at all — the two rules whose every attempt failed
+  in that build left no file. So a rule that died after 30s and then succeeded in 2h reports 2h,
+  with no averaging and no trace of the failure. `leftover_umls` on babel-1.17 is the worked
+  example: attempts failed at 9885s, 17254s and 2148s, succeeded at ~2367s, and the benchmark
+  reads 2292s. `read_benchmarks()` does keep the per-column worst case across rows, but that only
+  fires for a `repeat()` rule.
+
+  Two consequences for a multi-run build. The benchmark set is a **mixture**: each rule's numbers
+  come from whichever run last succeeded at it, not from one coherent run. And a success is
+  *sticky* — a rule that succeeded in run 1 and then failed in run 3 still reports run 1's
+  numbers, which are real but older than the build you think you are sizing.
+
+- **The efficiency report: the per-column maximum over every attempt, failures included.** Its rows
+  are per job *step* (`53155.0`, `53155.1`, …), several per attempt and several attempts per rule,
+  and every shard is merged with `max`. Nothing consults a state column, so a failed attempt cannot
+  be excluded. That is harmless for the two fields actually consumed — a retry requests the same
+  memory and CPUs — but it is another reason not to reach for `Elapsed_sec`, which would take the
+  worst attempt including one killed at its time limit.
+
+- **`babel-slurm-errors`: one entry per attempt**, marked failed or not, which is the only one of
+  the three that can tell you a rule failed twice before it worked.
+
 The per-rule logs' start/end timestamps and failure state are the opposite case and are **not**
 parsed. Extracting those means matching free-form log text, which rots silently when Snakemake
 changes its output — and a test fixture cannot catch that, since it pins the format it was copied

--- a/docs/tools/Resources.md
+++ b/docs/tools/Resources.md
@@ -81,6 +81,12 @@ a median of 5s: the gap is job startup and teardown around the benchmarked body.
 `s` slightly *understates* the span the limit applies to. At the default `--safety 1.5` that is
 noise, but it is the reason not to trim a runtime to a hair above the benchmark.
 
+`Elapsed_sec` is parsed into `EfficiencyRow` and simply not used, which is deliberate: the column
+is reliable (unlike `MaxRSS`/`TotalCPU` on this cluster), and having it already parsed and
+documented is what a future "how long do jobs actually hold their allocation?" question needs. The
+same goes for `RuleLog.start`/`end`/`failed`. Nothing consumes them today; deleting them would
+throw away the part that took the work — knowing which artifact records which span.
+
 ### Units
 
 > **TODO** ([#1014](https://github.com/NCATSTranslator/Babel/issues/1014)): this whole section

--- a/docs/tools/Resources.md
+++ b/docs/tools/Resources.md
@@ -39,12 +39,14 @@ A Snakemake-on-SLURM run leaves three kinds of artifact under `babel_outputs/`:
   usually holds just a handful of rules. The reader therefore merges *all* shards (worst case per
   rule); reading only the newest would drop the requested-side data for almost every rule. When
   archiving a run, copy the whole directory, not just the newest file.
-- `logs/rule_<name>/<jobid>.log` — per-rule control-node logs. The only thing read out of them is
-  the declared `resources:` line, as a fallback for the requested side and as the first choice for
-  the runtime limit. A log also carries the job's own start/end timestamps and its failure state;
-  neither is parsed, and the comment above `RuleLog` in `src/tools/slurm/parse.py` says how to
-  extract them if you ever need to. **Every** wall-time figure in the report comes from the
-  benchmarks.
+- `logs/rule_<name>/<jobid>.log` — per-rule control-node logs. The only thing *this* tool reads out
+  of them is the declared `resources:` line, as a fallback for the requested side and as the first
+  choice for the runtime limit. A log also carries the job's own start/end timestamps and its
+  failure state; neither is parsed here, and the comment above `RuleLog` in
+  `src/tools/slurm/parse.py` says how to extract them if you ever need to. **Every** wall-time
+  figure in the report comes from the benchmarks. Do not trim these logs from an archive on the
+  strength of that, though: [`babel-slurm-errors`](Errors.md) reads the `runtime=` limit *and*
+  quotes the whole log for its failure excerpts.
 
 ### Why the benchmark TSVs, not the efficiency report
 
@@ -68,7 +70,7 @@ A run records a job's duration three times, over three different spans:
 |--------|--------|-------|
 | benchmark `s` | Snakemake, from inside the job | the rule's execution |
 | `Elapsed_sec` | sacct, via the efficiency report | job start → end |
-| `babel-slurm-errors`' duration | the control-node log | submit → finish |
+| `babel-slurm-errors`' duration | the aggregate sbatch `.err` log | submit → finish (but see below) |
 
 They are not interchangeable. [`babel-slurm-errors`](Errors.md) subtracts the Snakemake *submit*
 timestamp, so its figure includes time the job spent **pending in the queue**; sacct's `Elapsed`
@@ -76,6 +78,15 @@ starts when the job is allocated and so excludes it. On the 2026jul22-era run un
 submit→finish exceeded `Elapsed_sec` by a median of 35s and a maximum of 306s (over 60s for 15 of
 57 rules) — small only because that cluster was mostly free. Do not read a long duration in the
 errors report as a slow rule without checking whether the job was waiting.
+
+**For a *failed* attempt, submit → finish is what that row should say and not yet what the tool
+prints.** `parse_job_events()` moves an attempt's finish timestamp on every `Error in rule` line it
+matches, and Snakemake emits that line twice: once when the job dies, and again in the end-of-run
+summary. So a failed job is timed to when the *run* gave up, not when it died. In the babel-1.18
+run, `process_ec_ids` was submitted at 04:56:58 and failed 39s later at 04:57:37; the summary
+repeated the line 23 hours on, and the tool reports "failed after 23h24m". Until
+[#1020](https://github.com/NCATSTranslator/Babel/issues/1020) lands, treat a failed attempt's
+duration as an upper bound on the whole run, not a measurement of the job.
 
 `--time` polices `Elapsed`, which was ≥ the benchmark's `s` for **57 of 57** rules on that run, by
 a median of 5s: the gap is job startup and teardown around the benchmarked body. So sizing from

--- a/docs/tools/Resources.md
+++ b/docs/tools/Resources.md
@@ -43,8 +43,8 @@ A Snakemake-on-SLURM run leaves three kinds of artifact under `babel_outputs/`:
   of them is the declared `resources:` line, as a fallback for the requested side and as the first
   choice for the runtime limit. A log also carries the job's own start/end timestamps and its
   failure state; neither is parsed here, and the comment above `RuleLog` in
-  `src/tools/slurm/parse.py` says how to extract them if you ever need to. **Every** wall-time
-  figure in the report comes from the benchmarks. Do not trim these logs from an archive on the
+  `src/tools/slurm/parse.py` says how to extract them if you ever need to. **Every** wall time the
+  report *measures* comes from the benchmarks. Do not trim these logs from an archive on the
   strength of that, though: [`babel-slurm-errors`](Errors.md) reads the `runtime=` limit *and*
   quotes the whole log for its failure excerpts.
 
@@ -53,14 +53,17 @@ A Snakemake-on-SLURM run leaves three kinds of artifact under `babel_outputs/`:
 The efficiency report is the natural place to look for memory and CPU usage, but on Hatteras its
 `MaxRSS` and `TotalCPU` columns come back **empty** — the cluster's `jobacct_gather`/cgroup
 accounting isn't capturing per-step usage, so every `CPU Efficiency (%)` and `Memory Usage (%)` is
-`0`. The tool therefore uses the efficiency report only for the *requested* side
-(`RequestedMem_MB` and `NCPUS` — those two columns and no others) and relies on the `benchmark:`
-TSVs for actual usage. Because the recommendations come from the benchmarks, the override list
-(below) is reliable even when the requested side is sparse.
+`0`. The tool therefore consumes the efficiency report only for the *requested* side
+(`RequestedMem_MB` and `NCPUS` — those two columns and no others; the rest are parsed but unread,
+see `EfficiencyRow`) and relies on the `benchmark:` TSVs for actual usage. Because the
+recommendations come from the benchmarks, the override list (below) is reliable even when the
+requested side is sparse.
 
-That includes wall time: **every duration in the report is the benchmark TSV's `s` column**
+That includes wall time: **every duration the report measures is the benchmark TSV's `s` column**
 (`Benchmark.seconds`, the per-column worst case across a rule's rows), never the efficiency
-report's `Elapsed_sec` or the span between a log's timestamps.
+report's `Elapsed_sec` or the span between a log's timestamps. The durations it does *not* measure
+are the runtime limits it prints beside them, which come from the log, the snakefile, or the
+cluster default (see "Runtime fit" below).
 
 ### Three clocks, and which one a time limit polices
 

--- a/docs/tools/Resources.md
+++ b/docs/tools/Resources.md
@@ -57,9 +57,29 @@ TSVs for actual usage. Because the recommendations come from the benchmarks, the
 
 That includes wall time: **every duration in the report is the benchmark TSV's `s` column**
 (`Benchmark.seconds`, the per-column worst case across a rule's rows), never the efficiency
-report's `Elapsed_sec` or the span between a log's timestamps. Snakemake writes `s` from inside
-the job, so it measures execution and excludes SLURM queue time — the conservative choice for
-sizing a time limit, since the limit applies to execution too.
+report's `Elapsed_sec` or the span between a log's timestamps.
+
+### Three clocks, and which one a time limit polices
+
+A run records a job's duration three times, over three different spans:
+
+| Number | Source | Spans |
+|--------|--------|-------|
+| benchmark `s` | Snakemake, from inside the job | the rule's execution |
+| `Elapsed_sec` | sacct, via the efficiency report | job start → end |
+| `babel-slurm-errors`' duration | the control-node log | submit → finish |
+
+They are not interchangeable. [`babel-slurm-errors`](Errors.md) subtracts the Snakemake *submit*
+timestamp, so its figure includes time the job spent **pending in the queue**; sacct's `Elapsed`
+starts when the job is allocated and so excludes it. On the 2026jul22-era run under `data/`,
+submit→finish exceeded `Elapsed_sec` by a median of 35s and a maximum of 306s (over 60s for 15 of
+57 rules) — small only because that cluster was mostly free. Do not read a long duration in the
+errors report as a slow rule without checking whether the job was waiting.
+
+`--time` polices `Elapsed`, which was ≥ the benchmark's `s` for **57 of 57** rules on that run, by
+a median of 5s: the gap is job startup and teardown around the benchmarked body. So sizing from
+`s` slightly *understates* the span the limit applies to. At the default `--safety 1.5` that is
+noise, but it is the reason not to trim a runtime to a hair above the benchmark.
 
 ### Units
 

--- a/src/tools/slurm/CLAUDE.md
+++ b/src/tools/slurm/CLAUDE.md
@@ -7,8 +7,10 @@ run. Full reference: [`docs/tools/Errors.md`](../../../docs/tools/Errors.md) and
 Both subcommands share `parse.py`. The one gotcha worth knowing before touching either: on Hatteras,
 `sacct`'s `MaxRSS`/`TotalCPU` come back empty, so the Snakemake `benchmark:` TSVs are the
 authoritative source for actual memory/CPU usage — never trust the SLURM efficiency report's usage
-columns. Wall time too: every duration `babel-slurm-resources` reports is the benchmark's `s`
-column, and the only efficiency-report columns it reads are `RequestedMem_MB` and `NCPUS`.
+columns. Wall time too: every duration `babel-slurm-resources` *measures* is the benchmark's `s`
+column (the runtime limits it prints alongside come from the log, the snakefile, or the cluster
+default), and the only efficiency-report columns it *consumes* are `RequestedMem_MB` and `NCPUS` —
+`parse.py` parses five, deliberately; see `EfficiencyRow`.
 `reports/slurm/slurm_efficiency_reports/` is a *directory* that accumulates one
 `efficiency_report_<uuid>.csv` shard per Snakemake restart (each covering only that invocation's
 jobs); `parse.py` merges them all, so copy the whole directory when archiving a run.

--- a/src/tools/slurm/CLAUDE.md
+++ b/src/tools/slurm/CLAUDE.md
@@ -4,10 +4,12 @@
 run. Full reference: [`docs/tools/Errors.md`](../../../docs/tools/Errors.md) and
 [`docs/tools/Resources.md`](../../../docs/tools/Resources.md).
 
-Both subcommands share `parse.py`. The one gotcha worth knowing before touching either: on
-Hatteras, `sacct`'s `MaxRSS`/`TotalCPU` come back empty, so the Snakemake `benchmark:` TSVs are
-the authoritative source for actual memory/CPU usage — never trust the SLURM efficiency report's
-usage columns. `reports/slurm/slurm_efficiency_reports/` is a *directory* that accumulates one
+Both subcommands share `parse.py`. The one gotcha worth knowing before touching either: on Hatteras,
+`sacct`'s `MaxRSS`/`TotalCPU` come back empty, so the Snakemake `benchmark:` TSVs are the
+authoritative source for actual memory/CPU usage — never trust the SLURM efficiency report's usage
+columns. Wall time too: every duration `babel-slurm-resources` reports is the benchmark's `s`
+column, and the only efficiency-report columns it reads are `RequestedMem_MB` and `NCPUS`.
+`reports/slurm/slurm_efficiency_reports/` is a *directory* that accumulates one
 `efficiency_report_<uuid>.csv` shard per Snakemake restart (each covering only that invocation's
 jobs); `parse.py` merges them all, so copy the whole directory when archiving a run.
 

--- a/src/tools/slurm/__init__.py
+++ b/src/tools/slurm/__init__.py
@@ -11,8 +11,8 @@ Why two requested-side sources? On the RENCI Hatteras cluster the built-in SLURM
 efficiency report's ``MaxRSS`` and ``TotalCPU`` columns come back empty (the
 ``jobacct_gather``/cgroup accounting isn't capturing them), so its memory/CPU
 *usage* numbers are unusable. The Snakemake ``benchmark:`` TSVs are therefore the
-authoritative source for actual usage; the efficiency report is used only for the
-*requested* mem/cpus and elapsed wall time. See ``docs/tools/Resources.md``.
+authoritative source for actual usage — wall time included — and the efficiency
+report is used only for the *requested* mem/cpus. See ``docs/tools/Resources.md``.
 
 Run with::
 

--- a/src/tools/slurm/errors.py
+++ b/src/tools/slurm/errors.py
@@ -93,6 +93,13 @@ def print_job_summary(err_file: Path, logs_dir: Path) -> None:
         for group, running in sorted(incomplete_groups, key=lambda x: x[0][0].submitted_at):
             prior_failures = [j for j in group if j.failed]
             j = running[0]
+            # Two different clocks: `elapsed` runs from Snakemake's *submit*, so it includes queue
+            # wait, while `timeout_min` is the rule's `runtime=`, which SLURM applies to `Elapsed`
+            # (allocation start -> end). Nothing in the .err log records the allocation start, so
+            # the queue wait cannot be subtracted without asking sacct. It only ever makes `elapsed`
+            # too big, hence the ">=" on the remaining figure -- the job has at least that much of
+            # its limit left, and more the busier the cluster was. See "Three clocks" in
+            # docs/tools/Resources.md.
             elapsed = (now - j.submitted_at).total_seconds()
             timeout_min = declared_runtime_min(j.log_relative, logs_dir)
             elapsed_str = _fmt_duration(elapsed)
@@ -100,7 +107,7 @@ def print_job_summary(err_file: Path, logs_dir: Path) -> None:
             remaining_str = _fmt_duration(max(0.0, timeout_min * 60 - elapsed))
             print(
                 f" - Rule {j.rule_name} (SLURM jobid {j.slurm_jobid}):"
-                f" {elapsed_str} / {timeout_str} ({remaining_str} left),"
+                f" {elapsed_str} / {timeout_str} (>={remaining_str} left),"
                 f" log at {logs_dir / j.log_relative}",
                 file=sys.stderr,
             )

--- a/src/tools/slurm/parse.py
+++ b/src/tools/slurm/parse.py
@@ -74,6 +74,13 @@ def read_benchmarks(benchmarks_dir: str | Path) -> dict[str, Benchmark]:
     """Read every ``*.tsv`` benchmark in ``benchmarks_dir`` keyed by rule name.
 
     The rule name is the file stem (``anatomy_compendia.tsv`` -> ``anatomy_compendia``).
+
+    What this measures across retries and repeated runs: Snakemake rewrites the file on each
+    execution and writes nothing for a job that failed, so a rule's row is its **last successful**
+    execution -- a rule that died after 30s and then succeeded in 2h reads as 2h. The per-column
+    worst case taken here therefore only matters for a ``repeat()`` rule; every file in the
+    2026jul22 build held a single row. See "What a retry, or a second run, does to each number" in
+    ``docs/tools/Resources.md``.
     """
     benchmarks_dir = Path(benchmarks_dir)
     result: dict[str, Benchmark] = {}
@@ -159,6 +166,11 @@ def read_efficiency_report(path: str | Path) -> dict[str, EfficiencyRow]:
     Merges every shard (see :func:`_efficiency_csvs`); when a rule appears in more than one shard
     (retries across restarts) we keep the per-column worst case, mirroring how
     :func:`read_benchmarks` keeps the worst observed run.
+
+    Unlike the benchmarks, this includes **failed** attempts: rows are per job step, several per
+    attempt, and no state column is consulted. Harmless for the two fields consumed -- a retry asks
+    for the same memory and CPUs -- but it is why ``elapsed_sec`` would be the wrong source for a
+    duration, since a job killed at its time limit would win the ``max``.
     """
     result: dict[str, EfficiencyRow] = {}
     for csv_path in _efficiency_csvs(path):

--- a/src/tools/slurm/parse.py
+++ b/src/tools/slurm/parse.py
@@ -103,19 +103,31 @@ def read_benchmarks(benchmarks_dir: str | Path) -> dict[str, Benchmark]:
 class EfficiencyRow:
     """Per-rule row from the SLURM executor's efficiency report.
 
-    ``max_rss_mb`` and ``total_cpu_sec`` are frequently 0 on clusters without
-    ``jobacct_gather``/cgroup accounting (the reason we trust :class:`Benchmark`
-    for usage). ``requested_mem_mb`` and ``ncpus`` are always reliable, and they
-    are the only two fields the resources report consumes -- every wall-time
-    figure it prints comes from :attr:`Benchmark.seconds`, i.e. the benchmark
-    TSV's ``s`` column, not from the report's ``Elapsed_sec``. The two usage
-    columns are kept because reading 0 out of them is how you *confirm* the
-    accounting is missing rather than assume it.
+    Only ``requested_mem_mb`` and ``ncpus`` are consumed, by ``resources.py``'s
+    requested side. The rest are parsed and kept deliberately -- reading them is
+    how a future run *confirms* what this cluster does and does not record --
+    so do not delete one on the grounds that nothing imports it:
+
+    - ``max_rss_mb`` and ``total_cpu_sec`` come back 0 on clusters without
+      ``jobacct_gather``/cgroup accounting, which is why :class:`Benchmark` is
+      the authority on usage. A run where they are non-zero means Hatteras
+      started recording per-step accounting, and the tool could stop relying on
+      the benchmarks for rules that have no ``benchmark:`` block.
+    - ``elapsed_sec`` is sacct's ``Elapsed``: the job's **allocation** span,
+      start to end. It is *not* what the report prints -- every wall-time figure
+      there is :attr:`Benchmark.seconds`, the benchmark TSV's ``s`` column,
+      which times the rule body from inside the job. The difference is the job's
+      setup and teardown (``Elapsed`` exceeded ``s`` for 57 of 57 rules on the
+      2026jul22 run, median 5s), and ``--time`` polices ``Elapsed``. Note that
+      neither includes time spent pending in the queue; the only number that
+      does is ``babel-slurm-errors``', which subtracts the *submit* timestamp.
+      See "Three clocks" in ``docs/tools/Resources.md``.
     """
 
     rule: str
     requested_mem_mb: float
     ncpus: int
+    elapsed_sec: float
     total_cpu_sec: float
     max_rss_mb: float
 
@@ -160,6 +172,7 @@ def read_efficiency_report(path: str | Path) -> dict[str, EfficiencyRow]:
                     rule=rule,
                     requested_mem_mb=_to_float(row.get("RequestedMem_MB")),
                     ncpus=int(_to_float(row.get("NCPUS"))),
+                    elapsed_sec=_to_float(row.get("Elapsed_sec")),
                     total_cpu_sec=_to_float(row.get("TotalCPU_sec")),
                     max_rss_mb=_to_float(row.get("MaxRSS_MB")),
                 )
@@ -171,6 +184,7 @@ def read_efficiency_report(path: str | Path) -> dict[str, EfficiencyRow]:
                         rule=rule,
                         requested_mem_mb=max(prev.requested_mem_mb, new.requested_mem_mb),
                         ncpus=max(prev.ncpus, new.ncpus),
+                        elapsed_sec=max(prev.elapsed_sec, new.elapsed_sec),
                         total_cpu_sec=max(prev.total_cpu_sec, new.total_cpu_sec),
                         max_rss_mb=max(prev.max_rss_mb, new.max_rss_mb),
                     )
@@ -188,7 +202,16 @@ _FAILURE_RE = re.compile(r"Error in rule |RuleException|Traceback \(most recent 
 
 @dataclass
 class RuleLog:
-    """Declared resources, wall-clock span, and failure state from a rule's log."""
+    """Declared resources, wall-clock span, and failure state from a rule's log.
+
+    ``resources.py`` consumes only ``mem_mb``/``runtime_min``/``cpus``. ``start``, ``end`` and
+    ``failed`` are kept for the same reason as :class:`EfficiencyRow`'s spare columns, but they
+    carry a risk those don't: they come from matching free-form log text (``_BRACKET_TS_RE``,
+    ``_FAILURE_RE``) rather than reading a named CSV column, so a change to Snakemake's log format
+    would break them silently while nothing consumed them. That is why
+    ``test_read_rule_logs_parses_resources_and_failure`` runs against lines copied verbatim out of
+    a real log rather than an invented one.
+    """
 
     rule: str
     job_id: str

--- a/src/tools/slurm/parse.py
+++ b/src/tools/slurm/parse.py
@@ -6,8 +6,9 @@ run-analysis directory such as ``data/babel-1.17/``:
 - ``benchmarks/<rule>.tsv``     — Snakemake ``benchmark:`` output (actual usage).
 - ``reports/slurm/slurm_efficiency_reports/`` — the SLURM executor's efficiency
   report (a *directory* containing ``efficiency_report_*.csv``).
-- ``logs/rule_<name>/<jobid>.log`` — per-rule control-node logs (declared resources,
-  timestamps, tracebacks).
+- ``logs/rule_<name>/<jobid>.log`` — per-rule control-node logs. Only the declared
+  ``resources:`` block is read out of these; see :class:`RuleLog` for what else is in
+  there and why it is documented rather than parsed.
 
 Every reader tolerates partial runs and missing/``NA``/``-`` cells.
 """
@@ -196,21 +197,37 @@ def read_efficiency_report(path: str | Path) -> dict[str, EfficiencyRow]:
 _MEM_RE = re.compile(r"\bmem_mb=(\d+)")
 _RUNTIME_RE = re.compile(r"\bruntime=(\d+)")
 _CPUS_RE = re.compile(r"\bcpus_per_task=(\d+)")
-_BRACKET_TS_RE = re.compile(r"\[(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (\w+ +\d+ [\d:]+ \d{4})\]")
-_FAILURE_RE = re.compile(r"Error in rule |RuleException|Traceback \(most recent call last\):")
+
+# A per-rule log also carries the job's wall-clock span and whether it failed, and this parser used
+# to extract both into fields nothing read. Regexes over free-form log text rot silently when
+# Snakemake changes its output, and a frozen test fixture cannot catch that -- it pins the format we
+# copied it from, not the one the cluster emits next year. So the extraction is written down here
+# instead of carried as code, for whoever needs it:
+#
+# - **Span.** Each phase is announced by a bracketed local timestamp on its own line, e.g.
+#   `[Mon Jul 13 00:57:13 2026]` (`%b %d %H:%M:%S %Y`, day space-padded). Take the first and last
+#   in the file: `re.compile(r"\[(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (\w+ +\d+ [\d:]+ \d{4})\]")`.
+#   That span covers the job's own execution, so it is close to the benchmark's `s` rather than to
+#   sacct's `Elapsed` -- see "Three clocks" in docs/tools/Resources.md before comparing it to
+#   anything.
+# - **Failure.** `Error in rule `, `RuleException`, or `Traceback (most recent call last):` appears
+#   in a failed attempt's log. Note this has to be checked in *every* attempt's log, not just the
+#   newest, since a rule that failed twice and then succeeded leaves all three.
+#
+# Prefer `parse_job_events()` (below) over either: the aggregate sbatch `.err` log names every
+# attempt with submit and finish timestamps in one place, which is what `babel-slurm-errors` reports
+# from. Reach for the per-rule logs only when that file is gone.
+# `logs/rule_process_ec_ids/52504.log` in the babel-1.18 run of 2026-07-13 is a worked example of
+# both markers.
 
 
 @dataclass
 class RuleLog:
-    """Declared resources, wall-clock span, and failure state from a rule's log.
+    """The ``resources:`` a rule's job declared, read from its newest log.
 
-    ``resources.py`` consumes only ``mem_mb``/``runtime_min``/``cpus``. ``start``, ``end`` and
-    ``failed`` are kept for the same reason as :class:`EfficiencyRow`'s spare columns, but they
-    carry a risk those don't: they come from matching free-form log text (``_BRACKET_TS_RE``,
-    ``_FAILURE_RE``) rather than reading a named CSV column, so a change to Snakemake's log format
-    would break them silently while nothing consumed them. That is why
-    ``test_read_rule_logs_parses_resources_and_failure`` runs against lines copied verbatim out of
-    a real log rather than an invented one.
+    Only what ``resources.py`` consumes: the declared block is a fallback for the requested side
+    (:class:`EfficiencyRow` first) and the first choice for the runtime limit. The comment above
+    covers the span and failure state this deliberately does not extract.
     """
 
     rule: str
@@ -219,28 +236,13 @@ class RuleLog:
     mem_mb: int | None
     runtime_min: int | None
     cpus: int | None
-    start: datetime | None
-    end: datetime | None
-    failed: bool
-
-
-def _parse_bracket_timestamps(text: str) -> tuple[datetime | None, datetime | None]:
-    stamps = []
-    for match in _BRACKET_TS_RE.finditer(text):
-        try:
-            stamps.append(datetime.strptime(match.group(1), "%b %d %H:%M:%S %Y"))
-        except ValueError:
-            continue
-    if not stamps:
-        return None, None
-    return stamps[0], stamps[-1]
 
 
 def read_rule_logs(logs_dir: str | Path) -> dict[str, RuleLog]:
-    """Walk ``logs_dir/rule_<name>/<jobid>.log`` and summarize each rule.
+    """Walk ``logs_dir/rule_<name>/<jobid>.log`` and read each rule's declared ``resources:``.
 
-    When a rule has several job logs (retries), the declared resources come from
-    the newest log and ``failed`` is True if *any* attempt's log shows a failure.
+    When a rule has several job logs (retries) only the newest is read: a retry declares the same
+    block as the attempt before it unless the snakefile changed mid-run.
     """
     logs_dir = Path(logs_dir)
     result: dict[str, RuleLog] = {}
@@ -251,20 +253,11 @@ def read_rule_logs(logs_dir: str | Path) -> dict[str, RuleLog]:
         logs = sorted(rule_dir.glob("*.log"), key=lambda p: p.stat().st_mtime)
         if not logs:
             continue
-        any_failed = False
         newest = logs[-1]
-        newest_text = ""
-        for log in logs:
-            text = log.read_text(errors="replace")
-            if _FAILURE_RE.search(text):
-                any_failed = True
-            if log == newest:
-                newest_text = text
-        text = newest_text
+        text = newest.read_text(errors="replace")
         mem = _MEM_RE.search(text)
         runtime = _RUNTIME_RE.search(text)
         cpus = _CPUS_RE.search(text)
-        start, end = _parse_bracket_timestamps(text)
         result[rule] = RuleLog(
             rule=rule,
             job_id=newest.stem,
@@ -272,9 +265,6 @@ def read_rule_logs(logs_dir: str | Path) -> dict[str, RuleLog]:
             mem_mb=int(mem.group(1)) if mem else None,
             runtime_min=int(runtime.group(1)) if runtime else None,
             cpus=int(cpus.group(1)) if cpus else None,
-            start=start,
-            end=end,
-            failed=any_failed,
         )
     return result
 

--- a/src/tools/slurm/parse.py
+++ b/src/tools/slurm/parse.py
@@ -125,8 +125,8 @@ class EfficiencyRow:
       started recording per-step accounting, and the tool could stop relying on
       the benchmarks for rules that have no ``benchmark:`` block.
     - ``elapsed_sec`` is sacct's ``Elapsed``: the job's **allocation** span,
-      start to end. It is *not* what the report prints -- every wall-time figure
-      there is :attr:`Benchmark.seconds`, the benchmark TSV's ``s`` column,
+      start to end. It is *not* what the report prints -- every wall time
+      measured there is :attr:`Benchmark.seconds`, the benchmark TSV's ``s`` column,
       which times the rule body from inside the job. The difference is the job's
       setup and teardown (``Elapsed`` exceeded ``s`` for 57 of 57 rules on the
       2026jul22 run, median 5s), and ``--time`` polices ``Elapsed``. Note that

--- a/src/tools/slurm/parse.py
+++ b/src/tools/slurm/parse.py
@@ -105,13 +105,17 @@ class EfficiencyRow:
 
     ``max_rss_mb`` and ``total_cpu_sec`` are frequently 0 on clusters without
     ``jobacct_gather``/cgroup accounting (the reason we trust :class:`Benchmark`
-    for usage). ``requested_mem_mb`` and ``ncpus`` are always reliable.
+    for usage). ``requested_mem_mb`` and ``ncpus`` are always reliable, and they
+    are the only two fields the resources report consumes -- every wall-time
+    figure it prints comes from :attr:`Benchmark.seconds`, i.e. the benchmark
+    TSV's ``s`` column, not from the report's ``Elapsed_sec``. The two usage
+    columns are kept because reading 0 out of them is how you *confirm* the
+    accounting is missing rather than assume it.
     """
 
     rule: str
     requested_mem_mb: float
     ncpus: int
-    elapsed_sec: float
     total_cpu_sec: float
     max_rss_mb: float
 
@@ -156,7 +160,6 @@ def read_efficiency_report(path: str | Path) -> dict[str, EfficiencyRow]:
                     rule=rule,
                     requested_mem_mb=_to_float(row.get("RequestedMem_MB")),
                     ncpus=int(_to_float(row.get("NCPUS"))),
-                    elapsed_sec=_to_float(row.get("Elapsed_sec")),
                     total_cpu_sec=_to_float(row.get("TotalCPU_sec")),
                     max_rss_mb=_to_float(row.get("MaxRSS_MB")),
                 )
@@ -168,7 +171,6 @@ def read_efficiency_report(path: str | Path) -> dict[str, EfficiencyRow]:
                         rule=rule,
                         requested_mem_mb=max(prev.requested_mem_mb, new.requested_mem_mb),
                         ncpus=max(prev.ncpus, new.ncpus),
-                        elapsed_sec=max(prev.elapsed_sec, new.elapsed_sec),
                         total_cpu_sec=max(prev.total_cpu_sec, new.total_cpu_sec),
                         max_rss_mb=max(prev.max_rss_mb, new.max_rss_mb),
                     )

--- a/src/tools/slurm/parse.py
+++ b/src/tools/slurm/parse.py
@@ -6,9 +6,12 @@ run-analysis directory such as ``data/babel-1.17/``:
 - ``benchmarks/<rule>.tsv``     — Snakemake ``benchmark:`` output (actual usage).
 - ``reports/slurm/slurm_efficiency_reports/`` — the SLURM executor's efficiency
   report (a *directory* containing ``efficiency_report_*.csv``).
-- ``logs/rule_<name>/<jobid>.log`` — per-rule control-node logs. Only the declared
-  ``resources:`` block is read out of these; see :class:`RuleLog` for what else is in
-  there and why it is documented rather than parsed.
+- ``logs/rule_<name>/<jobid>.log`` — per-rule control-node logs. ``babel-slurm-resources``
+  reads only the declared ``resources:`` block out of these; see :class:`RuleLog` for what
+  else is in there and why it is documented rather than parsed. ``babel-slurm-errors`` reads
+  more: :func:`declared_runtime_min` takes the ``runtime=`` limit and
+  :func:`extract_error_content` quotes the whole log, so an archived run needs these files
+  intact for the failure report, not just for the requested side.
 
 Every reader tolerates partial runs and missing/``NA``/``-`` cells.
 """

--- a/tests/tools/slurm/test_parse.py
+++ b/tests/tools/slurm/test_parse.py
@@ -98,15 +98,18 @@ def test_read_efficiency_report_merges_all_shards_worst_case(tmp_path):
 # --- parse.read_rule_logs ----------------------------------------------------
 
 
-def test_read_rule_logs_parses_resources_and_failure(tmp_path):
+def test_read_rule_logs_parses_declared_resources(tmp_path):
     """Every line here is copied verbatim from a real log, not composed to suit the parser.
 
     Source: `logs/rule_process_ec_ids/52504.log` from the babel-1.18 run of 2026-07-13 (the job
     that failed on a missing `babel_downloads/EC/enzyme.rdf`), lines 31, 32, 37, 81-83, 95 and 96.
     A real `resources:` line carries keys an invented one omits -- `mem_mib` and `disk_mib` sit
     beside `mem_mb`, and `disk_mb` precedes it -- which is exactly what `_MEM_RE`'s `\\bmem_mb=`
-    has to not confuse. `start`/`end`/`failed` have no consumer, so this fixture is the only thing
-    that would notice Snakemake changing the format underneath them.
+    has to not confuse; the fixture this replaced had none of them.
+
+    The failure and timestamp lines are kept in the fixture even though nothing reads them now:
+    they are what a real log looks like around the `resources:` line, and the comment in `parse.py`
+    that documents how to extract them points here.
     """
     logs = tmp_path / "logs"
     rdir = logs / "rule_process_ec_ids"
@@ -127,9 +130,7 @@ def test_read_rule_logs_parses_resources_and_failure(tmp_path):
     log = out["process_ec_ids"]
     # mem_mb, not mem_mib (15259) and not disk_mb (50000).
     assert (log.mem_mb, log.runtime_min, log.cpus) == (16000, 120, 1)
-    assert log.failed is True
-    assert log.start is not None and log.end is not None
-    assert (log.end - log.start).total_seconds() == 4
+    assert log.job_id == "52504"
 
 
 # --- parse.extract_error_content ---------------------------------------------

--- a/tests/tools/slurm/test_parse.py
+++ b/tests/tools/slurm/test_parse.py
@@ -99,23 +99,37 @@ def test_read_efficiency_report_merges_all_shards_worst_case(tmp_path):
 
 
 def test_read_rule_logs_parses_resources_and_failure(tmp_path):
+    """Every line here is copied verbatim from a real log, not composed to suit the parser.
+
+    Source: `logs/rule_process_ec_ids/52504.log` from the babel-1.18 run of 2026-07-13 (the job
+    that failed on a missing `babel_downloads/EC/enzyme.rdf`), lines 31, 32, 37, 81-83, 95 and 96.
+    A real `resources:` line carries keys an invented one omits -- `mem_mib` and `disk_mib` sit
+    beside `mem_mb`, and `disk_mb` precedes it -- which is exactly what `_MEM_RE`'s `\\bmem_mb=`
+    has to not confuse. `start`/`end`/`failed` have no consumer, so this fixture is the only thing
+    that would notice Snakemake changing the format underneath them.
+    """
     logs = tmp_path / "logs"
-    rdir = logs / "rule_anatomy_ncit_ids"
+    rdir = logs / "rule_process_ec_ids"
     rdir.mkdir(parents=True)
-    (rdir / "451.log").write_text(
-        "[Thu Jun  4 05:15:08 2026]\n"
-        "rule anatomy_ncit_ids:\n"
-        "    resources: tmpdir=<TBD>, disk_mb=50000, mem_mb=64000, mem=64 GB, runtime=120, cpus_per_task=4\n"
+    (rdir / "52504.log").write_text(
+        "[Mon Jul 13 00:57:13 2026]\n"
+        "rule process_ec_ids:\n"
+        "    resources: tmpdir=<TBD>, disk_mb=50000, disk=50 GB, disk_mib=47684, mem_mb=16000,"
+        " mem=16 GB, mem_mib=15259, runtime=120, cpus_per_task=1\n"
         "RuleException:\n"
-        "HTTP Error 503: Service Temporarily Unavailable\n"
-        "[Thu Jun  4 05:15:26 2026]\n"
+        'FileNotFoundError in file "/projects/babel/runs/gaurav/babel-1.18/src/snakefiles/process.snakefile", line 46:\n'
+        "[Errno 2] No such file or directory: 'babel_downloads/EC/enzyme.rdf'\n"
+        "[Mon Jul 13 00:57:17 2026]\n"
+        "Error in rule process_ec_ids:\n"
     )
     out = parse.read_rule_logs(logs)
-    assert "anatomy_ncit_ids" in out
-    log = out["anatomy_ncit_ids"]
-    assert (log.mem_mb, log.runtime_min, log.cpus) == (64000, 120, 4)
+    assert "process_ec_ids" in out
+    log = out["process_ec_ids"]
+    # mem_mb, not mem_mib (15259) and not disk_mb (50000).
+    assert (log.mem_mb, log.runtime_min, log.cpus) == (16000, 120, 1)
     assert log.failed is True
-    assert log.start is not None and log.end is not None and log.end > log.start
+    assert log.start is not None and log.end is not None
+    assert (log.end - log.start).total_seconds() == 4
 
 
 # --- parse.extract_error_content ---------------------------------------------

--- a/tests/tools/slurm/test_resources.py
+++ b/tests/tools/slurm/test_resources.py
@@ -49,11 +49,12 @@ def test_recommend_mem_rounds_up_to_bucket_with_floor():
 def test_wall_time_comes_from_the_benchmark_not_the_efficiency_report(tmp_path):
     """`wall_sec` is the benchmark TSV's `s` column, never the efficiency report's `Elapsed_sec`.
 
-    The two measure different things -- Snakemake times the job from the inside, SLURM times the
-    allocation -- so a report mixing them would size a time limit against a number that includes
-    queue time. The docs claimed the efficiency report's elapsed column was used; it never was. It
-    is still parsed into `EfficiencyRow.elapsed_sec` -- deliberately, see that class -- just never
-    consumed.
+    The two measure different things -- Snakemake times the rule body from inside the job, SLURM
+    times the allocation, which also covers the job's setup and teardown (`Elapsed_sec` >= `s` for
+    57 of 57 rules on the 2026jul22 run, median +5s). Neither includes queue wait; that is the
+    third clock, `babel-slurm-errors`'. The docs claimed the efficiency report's elapsed column was
+    used; it never was. It is still parsed into `EfficiencyRow.elapsed_sec` -- deliberately, see
+    that class -- just never consumed.
     """
     _make_run(tmp_path, "slow_rule", rss_mb=1000, mean_load=100.0, requested_mem_mb=8000)
     # The efficiency report disagrees with the benchmark by two orders of magnitude.

--- a/tests/tools/slurm/test_resources.py
+++ b/tests/tools/slurm/test_resources.py
@@ -51,8 +51,9 @@ def test_wall_time_comes_from_the_benchmark_not_the_efficiency_report(tmp_path):
 
     The two measure different things -- Snakemake times the job from the inside, SLURM times the
     allocation -- so a report mixing them would size a time limit against a number that includes
-    queue time. The docs claimed the efficiency report's elapsed column was used; it never was, and
-    it is no longer even parsed.
+    queue time. The docs claimed the efficiency report's elapsed column was used; it never was. It
+    is still parsed into `EfficiencyRow.elapsed_sec` -- deliberately, see that class -- just never
+    consumed.
     """
     _make_run(tmp_path, "slow_rule", rss_mb=1000, mean_load=100.0, requested_mem_mb=8000)
     # The efficiency report disagrees with the benchmark by two orders of magnitude.

--- a/tests/tools/slurm/test_resources.py
+++ b/tests/tools/slurm/test_resources.py
@@ -46,6 +46,26 @@ def test_recommend_mem_rounds_up_to_bucket_with_floor():
     assert resources.recommend_mem_mb(41 * 1000, safety=1.5, floor_mb=8000) == 64 * 1000
 
 
+def test_wall_time_comes_from_the_benchmark_not_the_efficiency_report(tmp_path):
+    """`wall_sec` is the benchmark TSV's `s` column, never the efficiency report's `Elapsed_sec`.
+
+    The two measure different things -- Snakemake times the job from the inside, SLURM times the
+    allocation -- so a report mixing them would size a time limit against a number that includes
+    queue time. The docs claimed the efficiency report's elapsed column was used; it never was, and
+    it is no longer even parsed.
+    """
+    _make_run(tmp_path, "slow_rule", rss_mb=1000, mean_load=100.0, requested_mem_mb=8000)
+    # The efficiency report disagrees with the benchmark by two orders of magnitude.
+    rep = tmp_path / "reports" / "slurm" / "slurm_efficiency_reports" / "efficiency_report_x.csv"
+    rep.write_text(
+        ",RuleName,NCPUS,Elapsed_sec,TotalCPU_sec,MaxRSS_MB,RequestedMem_MB\n0,rule_slow_rule,4,99999.0,0.0,,8000\n"
+    )
+
+    (rec,) = resources.analyze(tmp_path)
+
+    assert rec.wall_sec == 100.0
+
+
 def test_benchmark_mebibytes_are_converted_to_decimal_mb():
     """Snakemake's benchmark "MB" columns are mebibytes; SLURM's `mem` is decimal MB.
 


### PR DESCRIPTION
`docs/tools/Resources.md` said `babel-slurm-resources` reads "elapsed wall time" from the SLURM efficiency report, and that the per-rule logs' start/end timestamps feed the sizing. Checking the code, neither is true.

Every duration the report prints — the runtime-fit percentage, the recommendation, the "slowest rule still on the default" line, the tables and the CSV — comes from `Benchmark.seconds`, which `read_benchmarks()` takes from the benchmark TSV's `s` column (per-column worst case across a rule's rows). `EfficiencyRow.elapsed_sec` is parsed and merged across shards but read by nobody; the logs contribute their declared `resources:` line and nothing else.

The distinction is not cosmetic, and getting it right took measuring rather than reasoning. A run records a job's duration over three different spans: the benchmark's `s` (the rule's execution, timed from inside the job), sacct's `Elapsed_sec` (job start → end), and `babel-slurm-errors`' figure (submit → finish, so it includes time spent pending in the queue). Across the run under `data/`: `Elapsed_sec` ≥ `s` for **57 of 57** rules, median +5s — job setup and teardown; and submit→finish exceeded `Elapsed_sec` by a median of 35s, max 306s, over 60s for 15 rules. `--time` polices `Elapsed`, so sizing from `s` understates the policed span slightly, which is an argument against trimming a runtime to a hair above the benchmark.

## What a retry, or a second run, does to each number

A Babel build takes several `sbatch` runs and retries rules inside each, so "how long did this rule take" has three answers. Measured across the 2026jul22 and babel-1.17 builds (21 rules there have both failed and successful attempts):

- **Benchmarks — the last *successful* execution, nothing else.** Snakemake rewrites the TSV per execution (all 355 files in 2026jul22 hold one row) and writes none at all for a failed job: the two rules whose every attempt failed left no file. A rule that died at 30s and then succeeded in 2h reports 2h, with no averaging. `leftover_umls` on babel-1.17: failed at 9885s, 17254s, 2148s, succeeded at ~2367s, benchmark `2292s`. The per-column max in `read_benchmarks()` therefore only fires for `repeat()`.
- Two consequences for a multi-run build: the benchmark set is a **mixture** (each rule's numbers come from whichever run last succeeded at it), and a success is **sticky** — a rule that succeeded in run 1 and failed in run 3 still reports run 1's numbers.
- **Efficiency report — per-column max over every attempt, failures included.** Rows are per job step (`53155.0`, `.1`, …), several per attempt, and no state column is consulted. Harmless for the two fields consumed, and one more reason `Elapsed_sec` is the wrong source for a duration: a job killed at its time limit would win the `max`.
- **`babel-slurm-errors` — one entry per attempt**, marked failed or not; the only one of the three that can say a rule failed twice before it worked.

This turned up a real bug in that third tool — a failed attempt's reported duration is the time from submit to the **end of the whole run** (`process_ec_ids`: died in 39s, reported 84,260s), because Snakemake logs `Error in rule` a second time in its end-of-run summary and `parse_job_events()` keeps the later timestamp. The fix is #1020; nothing here depends on it, but since this PR is what documents the submit → finish clock, the new section caveats that row rather than describing behaviour `main` does not have yet.

## What changed

- **The docs now say what the code does**, in the three places that were wrong: the artifacts list (the logs bullet), "Why the benchmark TSVs, not the efficiency report" (the efficiency report supplies `RequestedMem_MB` and `NCPUS`, those two columns and no others), and a new **"Three clocks, and which one a time limit polices"** section giving the table above with its measured gaps — so the next person comparing a `babel-slurm-errors` duration against an `Elapsed_sec` knows why they differ. `src/tools/slurm/CLAUDE.md` gets the one-line version, since that is where someone touching the parser looks first.
- **Every claim about the per-rule logs is scoped to the tool that makes it.** The logs bullet and `parse.py`'s module docstring both said that only the declared `resources:` block is read out of `logs/rule_<name>/<jobid>.log`. That is true of `babel-slurm-resources` and false of `babel-slurm-errors`, which takes the `runtime=` limit from those logs (`declared_runtime_min()`) and quotes them whole for its failure excerpts (`extract_error_content()`) — so as written the sentence was an invitation to trim them out of an archive and lose every excerpt the errors report prints. Relatedly, the three-clocks table now gives the source of the errors duration as the aggregate sbatch `.err` log, where `parse_job_events()` actually reads it, rather than the per-rule log the same page has just said it does not take timestamps from.
- **`babel-slurm-errors`' still-running line no longer mixes two of the three clocks.** Its `elapsed` runs from Snakemake's *submit* and so includes queue wait, but it was printed against `timeout_min` from the rule's declared `runtime=`, which SLURM applies to `Elapsed`. A job that pended 5 minutes under `runtime=120` printed `2h 0m / 2h (0s left)` while it still had 5 minutes of allocation, and the error grows with queue depth — the measurement above (submit → finish exceeding `Elapsed_sec` by up to 306s on a *mostly idle* cluster) is the argument that the two are not interchangeable. Nothing in the `.err` log records the allocation start, so the wait cannot be subtracted without asking sacct; the skew only ever inflates `elapsed`, so the column now prints `(>=N left)` and a comment names both clocks.
- **`EfficiencyRow.elapsed_sec` is kept, and now explains itself.** An earlier commit on this branch deleted it as dead data; that was the wrong lever. The docs drifted because they claimed the field was *used*, not because it existed, and the column is reliable (unlike `MaxRSS`/`TotalCPU` here) with a meaning worth keeping wired up. `EfficiencyRow`'s docstring now states which two fields are consumed and why each of the others is deliberately kept — `max_rss_mb`/`total_cpu_sec` read 0 on a cluster without per-step accounting, so a non-zero one is the signal that Hatteras started recording it.
- **A second new section, "What a retry, or a second run, does to each number"**, records the multi-run findings above, with the same points condensed onto `read_benchmarks()` and `read_efficiency_report()` — those docstrings are where someone lands when they wonder whether a number survived a retry.
- **A test pins the real source**: `test_wall_time_comes_from_the_benchmark_not_the_efficiency_report` builds a run whose efficiency report disagrees with the benchmark by two orders of magnitude (99999s vs 100s) and asserts the recommendation reports 100.

## Unread data is not automatically dead, but it isn't automatically safe either

Two kinds, and this PR treats them differently:

- **Named columns read into a float** — `elapsed_sec`, `max_rss_mb`, `total_cpu_sec` on `EfficiencyRow`. These cannot quietly start meaning something else, and if the cluster begins populating the usage columns they are already correct. Kept, with a docstring saying which two fields are consumed and why each of the rest earns its line.
- **Regexes over free-form log text** — `RuleLog.start`/`end`/`failed`, from `_BRACKET_TS_RE` and `_FAILURE_RE`. These rot silently when Snakemake changes its output, and no test can prevent it: a fixture pins the format it was copied from, not the one the cluster emits next year. **Removed**, and replaced by a comment above `RuleLog` giving the recipe — the bracketed-timestamp format and the fact that the span is the job's own execution (so it tracks `s`, not `Elapsed`), the three failure markers and the fact that they must be checked in *every* attempt's log rather than the newest, a real log to look at, and a pointer to `parse_job_events()` as the better source anyway.

Deleting them takes `_BRACKET_TS_RE`, `_FAILURE_RE` and `_parse_bracket_timestamps()` with them — no other caller — and lets `read_rule_logs()` read one log per rule instead of every retry's log in full, which it was doing solely to compute the unread `failed` flag.

The rule-log test keeps its verbatim fixture from `logs/rule_process_ec_ids/52504.log` (babel-1.18, 2026-07-13), because the point it proves is still live: a real `resources:` line reads `disk_mb=50000, disk=50 GB, disk_mib=47684, mem_mb=16000, mem=16 GB, mem_mib=15259`, so `mem_mib` and `disk_mb` sit right beside the value `_MEM_RE` has to pick out. The fixture it replaced had neither. Re-verified after the change: all 5 real logs under `data/logs` parse with `mem_mb` populated.

## Checks

`uv run pytest -m unit -q` — 507 passed. `ruff check`, `ruff format --check`, `rumdl check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

