### PR TITLE
Move each release note into its release directory

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -6,8 +6,8 @@ description: Prepare the combined Babel/NodeNorm/NameRes release notes. Use when
 # Preparing a Babel release note
 
 A Babel release is a build plus the NodeNorm and NameRes versions deployed against it, so the note
-in `releases/<release>.md` covers all three repositories. The goal is a note a Babel consumer can
-skim to answer: what changed, what is new, and what might now look different or broken.
+in `releases/<build>/README.md` covers all three repositories. The goal is a note a Babel consumer
+can skim to answer: what changed, what is new, and what might now look different or broken.
 
 `releases/scripts/draft_release_notes.py` does the mechanical half. This skill is the judgement
 half.
@@ -33,8 +33,11 @@ version was actually deployed. If the previous release's entry has no NodeNorm/N
 
 ```bash
 uv run python releases/scripts/draft_release_notes.py <release> \
-    --build-dir <copy of the build's output directory> > releases/<release>.md
+    --build-dir <copy of the build's output directory> > releases/<build>/README.md
 ```
+
+The note lives in the build's own directory, beside that build's archived reports — see
+`releases/ARTIFACTS.md`. For recent releases the build name and the release id are the same.
 
 `--build-dir` needs `reports/tables/` from the build; without it the count table and the
 notable-changes section come out as TODOs. The user usually has a copy under `data/`. An
@@ -172,8 +175,8 @@ reading pass rather than a re-derivation.
    ones:
 
    ```bash
-   for pr in $(grep -oE 'pull/[0-9]+' releases/<release>.md | cut -d/ -f2 | sort -u); do
-     hits=$(grep -l "pull/$pr\b" releases/*.md | grep -v "<release>" | tr '\n' ' ')
+   for pr in $(grep -oE 'pull/[0-9]+' releases/<build>/README.md | cut -d/ -f2 | sort -u); do
+     hits=$(grep -l "pull/$pr\b" releases/*/*.md | grep -v "<build>" | tr '\n' ' ')
      [ -n "$hits" ] && echo "#$pr also in: $hits"
    done
    ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,15 +204,15 @@ laptop in ~25 minutes; the README's 500 GB figure is for the heaviest targets on
 ## Releasing a build
 
 A Babel release is a build *plus* the NodeNorm and NameRes versions deployed against it, and the
-combined note lives in `releases/<release>.md`. `releases/releases.yaml` records which versions
+combined note lives in `releases/<build>/README.md`. `releases/releases.yaml` records which versions
 shipped with which build — that mapping is not derivable from anywhere else, and each entry is the
 next release's comparison baseline. [`releases/README.md`](releases/README.md) is the process, and
 `releases/scripts/draft_release_notes.py` drafts the mechanical parts.
 
-Each release also archives ~420 KB of that build's summary reports under `releases/<build>/`,
-mirroring the build directory's own paths so a release directory *is* a (tiny) build directory —
-`--build-dir releases/2026jul22` works unchanged. [`releases/ARTIFACTS.md`](releases/ARTIFACTS.md)
-says what each file is, and why a repo-wide lint or scan must exclude them.
+That directory also holds ~420 KB of the build's summary reports, mirroring the build directory's
+own paths so a release directory *is* a (tiny) build directory — `--build-dir releases/2026jul22`
+works unchanged. [`releases/ARTIFACTS.md`](releases/ARTIFACTS.md) says what each file is, and why a
+repo-wide lint or scan must exclude `reports/` and `metadata/` — but not the note beside them.
 
 A release is also the natural cadence for re-checking SLURM sizing against the run's benchmarks
 (`docs/tools/Resources.md`), and for the archive/pin steps in `docs/RunningBabel.md`.

--- a/docs/RunningBabel.md
+++ b/docs/RunningBabel.md
@@ -471,8 +471,8 @@ baseline to compare against:
    release's comparison, so a wrong value propagates forward. The 2026jul22 build shipped with
    `"name": "2026jul15"` for exactly this reason, which is why the check is no longer left to a
    human. If it fires, work out which release the value names before correcting it.
-2. Link the archive from the release's `releases/<release>.md` notes —
-   `draft_release_notes.py` emits those three links, keyed by build name.
+2. Link the archive from the release's `releases/<build>/README.md` note — `draft_release_notes.py`
+   emits those three links, now relative, since the note sits beside the archive.
 3. Commit. This copy becomes the reviewed baseline for the next release. Leave `config.yaml` alone
    here: `release_name` still names the build you just archived, and `previous_release` still names
    the baseline it was compared against.

--- a/releases/2023nov5/README.md
+++ b/releases/2023nov5/README.md
@@ -3,4 +3,4 @@
 - Babel: [2023nov5](https://stars.renci.org/var/babel_outputs/2023nov5/) (roughly Babel
   [v1.3.0](https://github.com/NCATSTranslator/Babel/releases/tag/v1.3.0))
 
-Next release: [May 2024](TranslatorMay2024.md)
+Next release: [May 2024](../2024mar24/README.md)

--- a/releases/2024aug18/README.md
+++ b/releases/2024aug18/README.md
@@ -2,10 +2,10 @@
 
 * Babel: [2024aug18](https://stars.renci.org/var/babel_outputs/2024aug18/) (approx
   [Babel 1.8.0](https://github.com/NCATSTranslator/Babel/releases/tag/v1.8.0))
-  * [CURIE summary](./2024aug18/reports/content/compendia_report.json)
+  * [CURIE summary](./reports/content/compendia_report.json)
 
-Next release: [Translator "Hammerhead" November 2024](./TranslatorHammerheadNovember2024.md)
-Previous release: [TranslatorFuguJuly2024](./TranslatorFuguJuly2024.md)
+Next release: [Translator "Hammerhead" November 2024](../2024oct24/README.md)
+Previous release: [TranslatorFuguJuly2024](../2024jul13/README.md)
 
 ## New features
 

--- a/releases/2024jul13/README.md
+++ b/releases/2024jul13/README.md
@@ -2,9 +2,9 @@
 
 * Babel: [2024jul13](https://stars.renci.org/var/babel_outputs/2024jul13/) (approx
   [Babel 2024jul13](https://github.com/NCATSTranslator/Babel/releases/tag/2024jul13))
-  * [CURIE summary](./2024jul13/reports/content/compendia_report.json)
+  * [CURIE summary](./reports/content/compendia_report.json)
 
-Next release: [TranslatorGuppyAugust2024](./TranslatorGuppyAugust2024.md)
+Next release: [TranslatorGuppyAugust2024](../2024aug18/README.md)
 
 ## New features
 
@@ -29,6 +29,6 @@ Next release: [TranslatorGuppyAugust2024](./TranslatorGuppyAugust2024.md)
 * Updated PANTHER pathways from SequenceAssociationPathway3.6.7.txt to
   SequenceAssociationPathway3.6.8.txt.
 
-## Releases since [May 2024](TranslatorMay2024.md)
+## Releases since [May 2024](../2024mar24/README.md)
 
 * No official releases

--- a/releases/2024mar24/README.md
+++ b/releases/2024mar24/README.md
@@ -2,9 +2,9 @@
 
 * Babel: [2024mar24](https://stars.renci.org/var/babel_outputs/2024mar24/) (approx
   [Babel v1.5.0](https://github.com/NCATSTranslator/Babel/releases/tag/v1.5.0))
-  * [CURIE summary](./2024mar24/reports/content/compendia_report.json)
+  * [CURIE summary](./reports/content/compendia_report.json)
 
-Next release: [Translator "Fugu" July 2024](TranslatorFuguJuly2024.md)
+Next release: [Translator "Fugu" July 2024](../2024jul13/README.md)
 
 ## New features
 
@@ -18,7 +18,7 @@ Next release: [Translator "Fugu" July 2024](TranslatorFuguJuly2024.md)
   in synonyms file.
 * Minor fixes.
 
-## Releases since [December 2023](TranslatorDecember2023.md)
+## Releases since [December 2023](../2023nov5/README.md)
 
 * [Babel v1.5.0](https://github.com/NCATSTranslator/Babel/releases/tag/v1.5.0):
   * Normalize DrugChemical conflation IDs by @gaurav in #250

--- a/releases/2024oct24/README.md
+++ b/releases/2024oct24/README.md
@@ -3,10 +3,10 @@
 - Babel: [2024oct24](https://stars.renci.org/var/babel_outputs/2024oct24/)
   ([tagged 2024oct24](https://github.com/NCATSTranslator/Babel/releases/tag/2024oct24),
   approx [Babel 1.8.0](https://github.com/NCATSTranslator/Babel/releases/tag/v1.8.0))
-  - [CURIE summary](./2024oct24/reports/content/compendia_report.json)
+  - [CURIE summary](./reports/content/compendia_report.json)
 
-Next release: [Babel 2025jan23](./2025jan23.md)
-Previous release: [Translator Guppy August 2024](./TranslatorGuppyAugust2024.md)
+Next release: [Babel 2025jan23](../2025jan23/README.md)
+Previous release: [Translator Guppy August 2024](../2024aug18/README.md)
 
 ## New features
 

--- a/releases/2025jan23/README.md
+++ b/releases/2025jan23/README.md
@@ -3,11 +3,11 @@
 - Babel: [2025jan23](https://stars.renci.org/var/babel_outputs/2025jan23/)
   ([tagged 2025jan23](https://github.com/NCATSTranslator/Babel/releases/tag/2025jan23),
   [Babel v1.9.1](https://github.com/NCATSTranslator/Babel/releases/tag/v1.9.1))
-  - [CURIE summary](./2025jan23/reports/content/compendia_report.json)
-  - [Prefix report](./2025jan23/reports/duckdb/prefix_report.json)
+  - [CURIE summary](./reports/content/compendia_report.json)
+  - [Prefix report](./reports/duckdb/prefix_report.json)
 
-Next release: [2025mar31](./2025mar31.md)
-Previous release: [Translator "Hammerhead" November 2024](./TranslatorHammerheadNovember2024.md)
+Next release: [2025mar31](../2025mar31/README.md)
+Previous release: [Translator "Hammerhead" November 2024](../2024oct24/README.md)
 
 ## New features
 

--- a/releases/2025mar31/README.md
+++ b/releases/2025mar31/README.md
@@ -3,11 +3,11 @@
 - Babel: [2025mar31](https://stars.renci.org/var/babel_outputs/2025mar31/)
   ([tagged 2025mar31](https://github.com/NCATSTranslator/Babel/releases/tag/2025mar31),
   [Babel v1.10.0](https://github.com/NCATSTranslator/Babel/releases/tag/v1.10.0))
-  - [CURIE summary](./2025mar31/reports/content/compendia_report.json)
-  - [Prefix report](./2025mar31/reports/duckdb/prefix_report.json)
+  - [CURIE summary](./reports/content/compendia_report.json)
+  - [Prefix report](./reports/duckdb/prefix_report.json)
 
-Next release: [v1.11](./v1.11.md)
-Previous release: [Translator "Hammerhead" November 2024](./TranslatorHammerheadNovember2024.md)
+Next release: [v1.11](../2025sep1/v1.11.md)
+Previous release: [Translator "Hammerhead" November 2024](../2024oct24/README.md)
 
 ## New features
 

--- a/releases/2025sep1.md
+++ b/releases/2025sep1.md
@@ -1,0 +1,7 @@
+# Babel 2025sep1
+
+This release note has moved to [`releases/2025sep1/README.md`](./2025sep1/README.md).
+
+This file is a temporary redirect, kept so the URLs NodeNorm and NameRes already publish keep
+working. **It will be deleted** once those have been pointed at the new location — see
+[Babel #1021](https://github.com/NCATSTranslator/Babel/issues/1021).

--- a/releases/2025sep1/README.md
+++ b/releases/2025sep1/README.md
@@ -4,15 +4,15 @@
   ([tagged 2025sep1](https://github.com/NCATSTranslator/Babel/releases/tag/2025sep1),
   [Babel v1.13](https://github.com/NCATSTranslator/Babel/releases/tag/v1.13))
   - Built against Biolink Model v4.2.6-rc5
-  - [CURIE summary](./2025sep1/reports/content/compendia_report.json)
-  - [Prefix report](./2025sep1/reports/duckdb/prefix_report.json)
+  - [CURIE summary](./reports/content/compendia_report.json)
+  - [Prefix report](./reports/duckdb/prefix_report.json)
 - NodeNorm: [v2.4.1](https://github.com/NCATSTranslator/NodeNormalization/releases/tag/v2.4.1)
 - NameRes: [v1.5.1](https://github.com/NCATSTranslator/NameResolution/releases/tag/v1.5.1),
   later updated in place to
   [v1.5.2](https://github.com/NCATSTranslator/NameResolution/releases/tag/v1.5.2)
 
-Next release: [2026jul22](./2026jul22.md)
-Previous release: [2025mar31](./2025mar31.md)
+Next release: [2026jul22](../2026jul22/README.md)
+Previous release: [2025mar31](../2025mar31/README.md)
 
 ## Bugfixes
 

--- a/releases/2025sep1/v1.11.md
+++ b/releases/2025sep1/v1.11.md
@@ -2,8 +2,8 @@
 
 - Babel: [Babel v1.11](https://github.com/NCATSTranslator/Babel/releases/tag/v1.11)
 
-Next release: [2025sep1](./2025sep1.md)
-Previous release: [2025mar31](./2025mar31.md)
+Next release: [2025sep1](./README.md)
+Previous release: [2025mar31](../2025mar31/README.md)
 
 ## Bugfixes
 

--- a/releases/2026jul22.md
+++ b/releases/2026jul22.md
@@ -1,0 +1,7 @@
+# Babel 2026jul22
+
+This release note has moved to [`releases/2026jul22/README.md`](./2026jul22/README.md).
+
+This file is a temporary redirect, kept so the URLs NodeNorm and NameRes already publish keep
+working. **It will be deleted** once those have been pointed at the new location — see
+[Babel #1021](https://github.com/NCATSTranslator/Babel/issues/1021).

--- a/releases/2026jul22/README.md
+++ b/releases/2026jul22/README.md
@@ -6,15 +6,15 @@
   `babel-1.18.1`)
   - Built against
     [Biolink Model v4.4.3](https://github.com/biolink/biolink-model/releases/tag/v4.4.3)
-  - [Summary tables](./2026jul22/reports/tables/)
-  - [CURIE summary](./2026jul22/reports/content/compendia_report.json)
-  - [Prefix report](./2026jul22/reports/duckdb/prefix_report.json)
+  - [Summary tables](./reports/tables/)
+  - [CURIE summary](./reports/content/compendia_report.json)
+  - [Prefix report](./reports/duckdb/prefix_report.json)
 - NodeNorm: [v2.5.0](https://github.com/NCATSTranslator/NodeNormalization/releases/tag/v2.5.0),
   [v2.5.1](https://github.com/NCATSTranslator/NodeNormalization/releases/tag/v2.5.1)
 - NameRes: [v1.7.0](https://github.com/NCATSTranslator/NameResolution/releases/tag/v1.7.0)
 
 Next release: *None as yet*
-Previous release: [Babel 2025sep1](./2025sep1.md)
+Previous release: [Babel 2025sep1](../2025sep1/README.md)
 
 ## Bugfixes
 
@@ -70,10 +70,10 @@ different.
   (22,809 -> 6,409) clique partners with them. Consumers resolving a phenotype by UMLS CUI will now
   get a leftover UMLS clique instead.
 - [MAJOR] **ChemicalEntity is down 87.2%** (4,046,131 -> 518,554), which unwinds the 510% jump
-  reported in [2025sep1](./2025sep1.md). The identifiers moved to SmallMolecule (+4.5%, +9.9M):
-  INCHIKEY in ChemicalEntity went 1,776,876 -> 55,437 and PUBCHEM.COMPOUND 1,647,448 -> 14,116,
-  while the corresponding SmallMolecule rows grew by about the same amounts. Chemicals that were
-  previously typed only as the generic `biolink:ChemicalEntity` now get a definite type.
+  reported in [2025sep1](../2025sep1/README.md). The identifiers moved to SmallMolecule (+4.5%,
+  +9.9M): INCHIKEY in ChemicalEntity went 1,776,876 -> 55,437 and PUBCHEM.COMPOUND 1,647,448 ->
+  14,116, while the corresponding SmallMolecule rows grew by about the same amounts. Chemicals that
+  were previously typed only as the generic `biolink:ChemicalEntity` now get a definite type.
 - **MacromolecularComplex is up 1,536%** (1,258 -> 20,579) -- all ComplexPortal species are now
   ingested ([Babel #831](https://github.com/NCATSTranslator/Babel/pull/831)).
 - **A new `Food` compendium** (932 CURIEs) from the DrugBank retype
@@ -99,7 +99,7 @@ different.
   `Polypeptide.txt` (leftover UMLS) is 214 in both releases -- the whole change is in this one file.
   The underlying prefix-registration mismatch predates this release and is worth an issue in its own
   right; it is written up in
-  [Architecture.md](../docs/Architecture.md#polypeptidetxt-is-a-residue-not-a-compendium).
+  [Architecture.md](../../docs/Architecture.md#polypeptidetxt-is-a-residue-not-a-compendium).
 
 ## Babel changes
 

--- a/releases/ARTIFACTS.md
+++ b/releases/ARTIFACTS.md
@@ -1,9 +1,10 @@
 # Archived build reports
 
 Each release directory here — [`2026jul22/`](2026jul22/), [`2025sep1/`](2025sep1/) and so on — holds
-a small subset of that build's own output: the summary tables, the per-compendium content reports,
-and the provenance metadata. A finished build is hundreds of gigabytes on a cluster that is
-eventually cleaned; this is the part worth keeping, about 420 KB per release.
+the release note as `README.md` plus a small subset of that build's own output: the summary tables,
+the per-compendium content reports, and the provenance metadata. A finished build is hundreds of
+gigabytes on a cluster that is eventually cleaned; this is the part worth keeping, about 420 KB per
+release.
 
 Directories are named by **build**, which is what every artifact and `config.yaml`'s
 `previous_release` pin already use. For recent releases that is also the release id; for the older
@@ -95,21 +96,29 @@ moved carries the previous build's name, and that value labels the baseline in t
 
 ## These files are build output, not repository content
 
-Everything under `releases/<build>/` is copied byte-for-byte out of a build. Nothing here is
-authored, and nothing here should be edited: an edit makes the archive disagree with the build it
-claims to be a subset of, which is the one property the layout rests on.
+Everything under `releases/<build>/reports/` and `releases/<build>/metadata/` is copied
+byte-for-byte out of a build. Nothing in those two subdirectories is authored, and nothing in them
+should be edited: an edit makes the archive disagree with the build it claims to be a subset of,
+which is the one property the layout rests on.
 
-That means **a repo-wide check that walks files has to exclude them**, and two already learned it
-the hard way:
+The Markdown at the directory root is the exception — `README.md` is the release note, and
+`2025sep1/v1.11.md` is the note for a release that never got a build of its own. Those are ordinary
+repository content, written by hand and edited like any other document.
+
+That means **a repo-wide check that walks files has to exclude the two build-output subdirectories,
+not the release directory** — a check scoped to the whole of `releases/<build>/` would stop looking
+at the notes, which are exactly the files it should be checking. Two checks already learned the
+first half the hard way:
 
 - `rumdl` (`[tool.rumdl] exclude` in `pyproject.toml`) — `prefix_comparison.md` is generated
   Markdown with long lines, and reflowing it would rewrite build output to satisfy a style rule.
 - `tests/test_docs_links.py` — two provenance YAMLs record an upstream URL pinned to `master`. That
   is what the build recorded, not a link this repository offers.
 
-If you add a third such check, exclude `releases/<build>/reports/` and `releases/<build>/metadata/`
-before the first archived release trips it. `releases/scripts/`, the notes and this file are
-ordinary repository content and stay in scope.
+Both are already scoped that way — rumdl excludes `releases/*/reports/` and
+`test_docs_links.py:_is_archived_build_report()` tests `parts[2] in {"reports", "metadata"}` — so
+neither needed changing when the notes moved in. If you add a third such check, scope it the same
+way. `releases/scripts/`, the notes and this file are ordinary repository content and stay in scope.
 
 ## What is not archived
 

--- a/releases/README.md
+++ b/releases/README.md
@@ -1,8 +1,11 @@
 # Babel Releases
 
-Each release below has a note, and most also have an archive of that build's summary tables and
-provenance metadata under `releases/<build>/` — see [`ARTIFACTS.md`](ARTIFACTS.md) for what those
-files are and how to read them.
+Each release has a directory named after its **build**, holding the note as `README.md` and — for
+most releases — an archive of that build's summary tables and provenance metadata. See
+[`ARTIFACTS.md`](ARTIFACTS.md) for what the archived files are and how to read them.
+
+For the Translator-named releases the build name is not the release name (`TranslatorFuguJuly2024`
+was built as `2024jul13`); the note's own title still names the release.
 
 ## General releases
 
@@ -10,16 +13,17 @@ files are and how to read them.
 
 ## Translator-specific releases
 
-- [2026jul22](2026jul22.md) ([summary tables](2026jul22/reports/tables/))
-- [2025sep1](2025sep1.md)
-- [Babel 1.11](v1.11.md)
-- [2025mar31](2025mar31.md)
-- [2025jan23](2025jan23.md)
-- [Translator "Hammerhead" November 2024](TranslatorHammerheadNovember2024.md)
-- [Translator "Guppy" August 2024](TranslatorGuppyAugust2024.md)
-- [Translator "Fugu" July 2024](TranslatorFuguJuly2024.md)
-- [May 2024](TranslatorMay2024.md)
-- [December 2023](TranslatorDecember2023.md)
+- [2026jul22](2026jul22/README.md) ([summary tables](2026jul22/reports/tables/))
+- [2025sep1](2025sep1/README.md)
+- [Babel 1.11](2025sep1/v1.11.md) — tagged but never deployed, so it has no build of its own; its
+  changes first shipped in 2025sep1, and the note is filed there.
+- [2025mar31](2025mar31/README.md)
+- [2025jan23](2025jan23/README.md)
+- [Translator "Hammerhead" November 2024](2024oct24/README.md)
+- [Translator "Guppy" August 2024](2024aug18/README.md)
+- [Translator "Fugu" July 2024](2024jul13/README.md)
+- [May 2024](2024mar24/README.md)
+- [December 2023](2023nov5/README.md)
 
 ## Preparing a release note
 
@@ -30,7 +34,7 @@ repositories, the upstream version bumps, and the per-compendium count table:
 
 ```bash
 uv run python releases/scripts/draft_release_notes.py 2026jul22 \
-    --build-dir /path/to/a/copy/of/the/build > releases/2026jul22.md
+    --build-dir /path/to/a/copy/of/the/build > releases/2026jul22/README.md
 ```
 
 Add the new release to `releases.yaml` first; the entry below it supplies the comparison baselines,

--- a/releases/releases.yaml
+++ b/releases/releases.yaml
@@ -10,11 +10,16 @@
 # v1.5.2" is not "everything numbered above v1.5.2", and a date sort is wrong too. Recording what
 # was actually deployed, and diffing with `gh api .../compare/BASE...HEAD`, gets it right.
 #
+# Notes live in the build's directory, as `releases/<build>/README.md`. `v1.11` is the one entry
+# with no build of its own, so its note is filed under the release its changes first shipped in, as
+# `releases/2025sep1/v1.11.md`.
+#
 # Fields (only `id` and `title` are required):
-#   id       File stem: this entry describes `releases/<id>.md`. For a deployed build this is also
-#            the release_name used for `releases/prefix_reports/<id>.json` and config.yaml.
+#   id       Release id. For a deployed build this is also the release_name used for
+#            `releases/<id>/reports/duckdb/prefix_report.json` and config.yaml.
 #   title    H1 of the note and its label in README.md.
-#   build    Name of the build's output directory on stars.renci.org. Omit if never deployed.
+#   build    Name of the build's output directory on stars.renci.org, and the name of the directory
+#            holding the note and the archived reports. Omit if never deployed.
 #   babel    Babel code release the build was cut from.
 #   branch   Release branch, when the build came off one rather than off the tag itself.
 #   approx   true when `babel` is the closest release rather than the exact commit built (the older
@@ -56,6 +61,8 @@ releases:
     # comparison starts at v1.5.2 and not at the numerically-later v1.6.2.
     nameres: ["v1.5.1", "v1.5.2"]
 
+  # Tagged but never shipped, so there is no build and no directory of its own; the note is filed
+  # under 2025sep1, the release its changes first reached Translator in.
   - id: v1.11
     title: Babel v1.11
     babel: v1.11

--- a/releases/scripts/draft_release_notes.py
+++ b/releases/scripts/draft_release_notes.py
@@ -10,7 +10,7 @@ Everything except the build directory comes from ``releases/releases.yaml``. The
 being drafted supplies the baselines, so the three PR ranges are derived rather than remembered::
 
     uv run python releases/scripts/draft_release_notes.py 2026jul22 \\
-        --build-dir /path/to/2026jul22 > releases/2026jul22.md
+        --build-dir /path/to/2026jul22 > releases/2026jul22/README.md
 
 PRs are collected with ``gh api .../compare/BASE...HEAD``, which asks GitHub for the commits reachable
 from HEAD but not from BASE. That is the only correct way to do this: NameRes v1.5.2 was cut *after*
@@ -544,12 +544,10 @@ def provenance_block(entry: dict, previous: dict | None, repo_root: Path = REPO_
     if entry.get("biolink"):
         lines.append(f"  - Built against Biolink Model v{entry['biolink']}")
     if build:
-        # Archived artifacts are keyed by *build*, not release id -- for the Translator-named
-        # releases those differ (id TranslatorFuguJuly2024, build 2024jul13), and linking by id
-        # pointed at files that were never there. See releases/ARTIFACTS.md.
-        lines.append(f"  - [Summary tables](./{build}/reports/tables/)")
-        lines.append(f"  - [CURIE summary](./{build}/reports/content/compendia_report.json)")
-        lines.append(f"  - [Prefix report](./{build}/reports/duckdb/prefix_report.json)")
+        # The note is `releases/<build>/README.md`, so it sits beside the archive it links into.
+        lines.append("  - [Summary tables](./reports/tables/)")
+        lines.append("  - [CURIE summary](./reports/content/compendia_report.json)")
+        lines.append("  - [Prefix report](./reports/duckdb/prefix_report.json)")
 
     for key, repo_key in (("nodenorm", "NodeNorm"), ("nameres", "NameRes")):
         versions = entry.get(key) or []
@@ -561,7 +559,11 @@ def provenance_block(entry: dict, previous: dict | None, repo_root: Path = REPO_
     lines.append("")
     lines.append("Next release: _None as yet_")
     if previous:
-        lines.append(f"Previous release: [{previous['title']}](./{previous['id']}.md)")
+        # Note directories are keyed by *build*, not release id -- for the Translator-named releases
+        # those differ (id TranslatorFuguJuly2024, build 2024jul13), and linking by id pointed at
+        # files that were never there. See releases/ARTIFACTS.md. `find_release` skips undeployed
+        # entries, so v1.11 -- the one note not at `<build>/README.md` -- never turns up here.
+        lines.append(f"Previous release: [{previous['title']}](../{previous.get('build') or previous['id']}/README.md)")
     return lines
 
 

--- a/tests/test_draft_release_notes.py
+++ b/tests/test_draft_release_notes.py
@@ -248,10 +248,15 @@ def test_ranges_use_the_last_service_version_deployed_against_each_build():
 def test_every_release_note_is_listed_in_the_manifest():
     """Drift guard: a new note in releases/ must be added to releases.yaml or the tooling won't see it."""
     releases_dir = get_repo_root() / "releases"
-    # README.md indexes the notes and ARTIFACTS.md documents the archived build reports; neither is
-    # a release note.
-    on_disk = {path.stem for path in releases_dir.glob("*.md")} - {"README", "ARTIFACTS"}
-    in_manifest = {entry["id"] for entry in drn.load_manifest(releases_dir / "releases.yaml")}
+    # A note is `releases/<build>/README.md`, keyed by the directory it sits in. The one exception is
+    # v1.11, which has no build of its own and is filed under 2025sep1 as `v1.11.md`, so a note that
+    # is not a README is keyed by its own stem instead. Top-level `*.md` is deliberately out of
+    # scope: README.md and ARTIFACTS.md are not notes, and the transitional redirect stubs left
+    # behind by https://github.com/NCATSTranslator/Babel/issues/1021 are not either.
+    on_disk = {p.parent.name if p.stem == "README" else p.stem for p in releases_dir.glob("*/*.md")}
+    # Keyed by build, because that is what the directory is named; entries with no build (v1.11) are
+    # keyed by id, which is the name their note file carries.
+    in_manifest = {entry.get("build") or entry["id"] for entry in drn.load_manifest(releases_dir / "releases.yaml")}
     assert on_disk == in_manifest
 
 

--- a/tests/test_draft_release_notes.py
+++ b/tests/test_draft_release_notes.py
@@ -303,29 +303,33 @@ def test_provenance_block_records_the_deployed_service_versions():
     # Both NodeNorm versions deployed against this build are listed, not just the latest.
     assert "NodeNorm: [v2.5.0]" in block and "[v2.5.1]" in block
     assert "NameRes: [v1.7.0]" in block
-    assert "Previous release: [Babel 2025sep1](./2025sep1.md)" in block
+    # The note is written to `releases/2026jul22/README.md`, so the archive is a sibling of the note
+    # and the previous release is one directory over.
+    assert "Previous release: [Babel 2025sep1](../2025sep1/README.md)" in block
     # 2026jul22 is a real tag, so the tag link is emitted.
     assert "[tagged 2026jul22](https://github.com/NCATSTranslator/Babel/releases/tag/2026jul22)" in block
-    assert "[Summary tables](./2026jul22/reports/tables/)" in block
-    assert "[Prefix report](./2026jul22/reports/duckdb/prefix_report.json)" in block
+    assert "[Summary tables](./reports/tables/)" in block
+    assert "[Prefix report](./reports/duckdb/prefix_report.json)" in block
 
 
 @pytest.mark.unit
-def test_archived_artifacts_are_linked_by_build_not_release_id():
-    """The archive directories are named by build, and for the older releases that is not the id.
+def test_a_sibling_note_is_linked_by_build_not_release_id():
+    """Release directories are named by build, and for the older releases that is not the id.
 
-    `TranslatorFuguJuly2024`'s build is `2024jul13`, which is what its CURIE summary has always been
-    filed under -- but the link was written from the release id, so it pointed at a path that never
-    existed. Nothing caught it because the four notes carrying it are historical.
+    `TranslatorFuguJuly2024`'s note and archive both live under `2024jul13`, so a link written from
+    the release id points at a path that never existed -- which is what the archive links used to
+    do, uncaught because the four notes carrying them are historical. The archive is now a sibling
+    of the note and needs no name at all; the cross-note link is where the distinction still bites.
     """
     manifest = drn.load_manifest(get_repo_root() / "releases" / "releases.yaml")
-    entry, previous = drn.find_release(manifest, "TranslatorFuguJuly2024")
+    entry, previous = drn.find_release(manifest, "TranslatorGuppyAugust2024")
     block = "\n".join(drn.provenance_block(entry, previous, get_repo_root()))
 
-    assert "[CURIE summary](./2024jul13/reports/content/compendia_report.json)" in block
-    assert "TranslatorFuguJuly2024/reports" not in block
-    # And the file it points at is really there.
-    assert (get_repo_root() / "releases" / "2024jul13" / "reports" / "content" / "compendia_report.json").exists()
+    assert 'Previous release: [Translator "Fugu" July 2024](../2024jul13/README.md)' in block
+    assert "TranslatorFuguJuly2024" not in block
+    # And the files both links point at are really there.
+    assert (get_repo_root() / "releases" / "2024jul13" / "README.md").exists()
+    assert (get_repo_root() / "releases" / "2024aug18" / "reports" / "content" / "compendia_report.json").exists()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes the first four checkboxes of #1021: every release note moves from `releases/<id>.md` into its release directory as `releases/<build>/README.md`, so one URL holds both the note and that build's archived reports and GitHub renders the note when you browse the directory.

## Redirects rather than duplicates

NodeNorm and NameRes publish `releases/2026jul22.md` and `releases/2025sep1.md` from their deployed About pages, so those two paths have to keep resolving until #1021's remaining checkboxes are done. The issue proposed duplicating the notes; this ships redirect stubs instead. A copy one directory down cannot be byte-identical — every relative link in a note (`./2026jul22/reports/tables/`, `./2025sep1.md`, `../docs/Architecture.md`) resolves differently from the new location — so the two files would diverge immediately and then have to be edited in lockstep, which 2026jul22's `Next release:` line guarantees would come up. Each stub is three lines: where the note went, that the file is temporary, and a link to #1021. Deleting them later is a two-file delete.

The other nine notes are plain `git mv` with no stub; nothing outside this repository links to them.

## Directory naming

Directories stay named by **build**, which is what the archives, `config.yaml`'s `previous_release` pin and `list_release_names()` already use, so `TranslatorFuguJuly2024.md` becomes `2024jul13/README.md`. Nothing is lost — each of those notes already names the release in its own title.

`v1.11` was tagged but never deployed and has no build directory. Giving it one would make `src/reports/prefix_comparison.py:list_release_names()` warn about a non-`YYYYmonDD` directory on every build, forever, so its note is filed under the release its changes first reached Translator in, as `releases/2025sep1/v1.11.md`. The two notes are not merged; `releases/README.md` keeps a separate index line pointing at it and says why it is there. `releases/2023nov5/` is a new directory holding only a note — that release predates the archives.

## What a reviewer should check

- The relative links inside the moved notes. `tests/test_docs_links.py::test_relative_links_resolve` covers all of them, and `releases/<build>/*.md` at the directory root is deliberately in its scope, so a missed rewrite fails the test rather than shipping.
- `releases/ARTIFACTS.md`'s "these files are build output, not repository content" rule, now narrowed to `reports/` and `metadata/` since the note sits at the directory root. Both existing repo-wide checks — rumdl's `releases/*/reports/` exclusion and `test_docs_links.py:_is_archived_build_report()` — were already scoped that way and needed no change. The section now says so explicitly, because widening either one to the whole release directory would stop it checking the notes, which are exactly the files it should check.
- The drift guard `test_every_release_note_is_listed_in_the_manifest`, rekeyed from `id` to `build or id` so it still matches the manifest exactly, including v1.11 and the four Translator-named entries.
- `draft_release_notes.py`'s provenance block: the three archive links lose their `{build}/` prefix (the note is now a sibling of the archive) and the previous-release link gains a `../<build>/` hop. The id-vs-build distinction that used to matter for the archive links still matters for that cross-note link, so `test_archived_artifacts_are_linked_by_build_not_release_id` moves over to guard it rather than going away.

Verified with `uv run python releases/scripts/draft_release_notes.py 2026jul22 --offline`, which still drafts from the committed archive alone and emits the new link forms. All four linters and the 506 unit tests pass.

## Follow-up

The rest of #1021, in another pass: update the NodeNorm CI, NameRes CI, and Exp/Dev About URLs, then delete the two stubs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
