### PR TITLE
Fix SAPBERT training data synonym duplication

### DIFF
--- a/slurm/README.md
+++ b/slurm/README.md
@@ -121,6 +121,7 @@ These rules have hard-coded `resources:` overrides and should not be reduced wit
 | `geneprotein_conflated_synonyms` | `geneprotein.snakefile` | 512G | 6h | Conflated synonym merge |
 | `drugchemical_conflation` | `drugchemical.snakefile` | 96G | — | Drug/chemical conflation (61.2 GB peak, was 96% of 64G) |
 | `geneprotein_conflation` | `geneprotein.snakefile` | 64G | — | Gene/protein conflation (~48G peak) |
+| `generate_sapbert_training_data` | `exports.snakefile` | 64G | 3h | Slowest wildcard instance 1.9h; estimate for the pair deduplication set, recheck against the benchmarks |
 | `get_uniprotkb_labels` | `datacollect.snakefile` | 48G | — | UniProtKB label parse (~40G peak) |
 | `hmdb_labels_and_synonyms` | `datacollect.snakefile` | 48G | — | HMDB XML parse (~30G peak) |
 | `check_protein_completeness` | `protein.snakefile` | 24G | — | Loads full Protein compendium (~21G peak) |
@@ -129,7 +130,6 @@ These rules have hard-coded `resources:` overrides and should not be reduced wit
 | `taxon_compendia` | `taxon.snakefile` | 24G | — | 15.1 GB peak, was 95% of the 16G default |
 | `chemical` | `chemical.snakefile` | — | 4h | Gzips every chemical synonyms file; 1.9h on both runs, 93% of the 2h default |
 | `generate_kgx` | `exports.snakefile` | — | 4h | Slowest wildcard instance 2.7h |
-| `generate_sapbert_training_data` | `exports.snakefile` | — | 3h | Slowest wildcard instance 1.9h |
 | `protein` | `protein.snakefile` | — | 4h | Gzips protein synonyms; `cpus_per_task=6` |
 | `drugchemical_conflated_synonyms` | `drugchemical.snakefile` | — | 4h | 2.7h on 2026jul22 |
 

--- a/src/exporters/sapbert.py
+++ b/src/exporters/sapbert.py
@@ -62,6 +62,7 @@ def convert_synonyms_to_sapbert(synonym_filename_gz, sapbert_filename_gzipped):
     count_entry = 0
     count_training_rows = 0
     count_smaller_rows = 0
+    seen_pairs = set()
     with (
         gzip.open(synonym_filename_gz, "rt", encoding="utf-8") as synonymf,
         gzip.open(sapbert_filename_gzipped, "wt", encoding="utf-8") as sapbertf,
@@ -116,12 +117,17 @@ def convert_synonyms_to_sapbert(synonym_filename_gz, sapbert_filename_gzipped):
                 name_pairs = [(preferred_name_normalized, names[0])]                
             else:
                 name_pairs = list(itertools.combinations(set(names), 2))
+
+            name_pairs = [
+                name_pair for name_pair in name_pairs if (biolink_type, *sorted(name_pair)) not in seen_pairs
+            ]
             
             if len(name_pairs) > MAX_SYNONYM_PAIRS:
                 # Randomly select 50 pairs.
                 name_pairs = random.sample(name_pairs, MAX_SYNONYM_PAIRS)
 
             for name_pair in name_pairs:
+                seen_pairs.add((biolink_type, *sorted(name_pair)))
                 line = f"biolink:{biolink_type}||{curie}||{preferred_name}||{name_pair[0]}||{name_pair[1]}\n"
                 sapbertf.write(line)
                 count_training_rows += 1

--- a/src/exporters/sapbert.py
+++ b/src/exporters/sapbert.py
@@ -83,7 +83,10 @@ def convert_synonyms_to_sapbert(synonym_filename_gz, sapbert_filename_gzipped):
             #    logging.warning(f"CURIE {curie} (preferred name: {preferred_name}) will be excluded from the Smaller training file.")
 
             # Collect and process the list of names.
-            names = entry["names"]
+            names = entry.get("names", [])
+            # Strip whitespace and drop empty strings if any
+            names = [name.strip() for name in names if name.strip()]
+            
             if LOWERCASE_ALL_NAMES:
                 names = [name.lower() for name in names]
 
@@ -102,37 +105,32 @@ def convert_synonyms_to_sapbert(synonym_filename_gz, sapbert_filename_gzipped):
             # How many names do we have?
             if len(names) == 0:
                 # This shouldn't happen, but let's anticipate this anyway.
-                line = f"biolink:{biolink_type}||{curie}||{preferred_name}||{preferred_name.lower()}||{preferred_name.lower()}\n"
-                sapbertf.write(line)
-                count_training_rows += 1
-                if generate_smaller_file and is_preferred_name_short:
-                    generate_smaller_file.write(line)
-                    count_smaller_rows += 1
+                continue
             elif len(names) == 1:
                 # If we have less than two names, we don't have anything to randomize.
-                line = f"biolink:{biolink_type}||{curie}||{preferred_name}||{preferred_name.lower()}||{names[0]}\n"
+                preferred_name_normalized = preferred_name.lower()
+                preferred_name_normalized = re.sub(r"\|\|+", "|", preferred_name_normalized)
+                if preferred_name_normalized == names[0]:
+                    # no need to write the synonym pair if they are identical
+                    continue
+                name_pairs = [(preferred_name_normalized, names[0])]                
+            else:
+                name_pairs = list(itertools.combinations(set(names), 2))
+            
+            if len(name_pairs) > MAX_SYNONYM_PAIRS:
+                # Randomly select 50 pairs.
+                name_pairs = random.sample(name_pairs, MAX_SYNONYM_PAIRS)
+
+            for name_pair in name_pairs:
+                line = f"biolink:{biolink_type}||{curie}||{preferred_name}||{name_pair[0]}||{name_pair[1]}\n"
                 sapbertf.write(line)
                 count_training_rows += 1
+
+                # As long as the preferred name is shorter than the right size, we should add this clique to the
+                # smaller file as well.
                 if generate_smaller_file and is_preferred_name_short:
                     generate_smaller_file.write(line)
                     count_smaller_rows += 1
-            else:
-                name_pairs = list(itertools.combinations(set(names), 2))
-
-                if len(name_pairs) > MAX_SYNONYM_PAIRS:
-                    # Randomly select 50 pairs.
-                    name_pairs = random.sample(name_pairs, MAX_SYNONYM_PAIRS)
-
-                for name_pair in name_pairs:
-                    line = f"biolink:{biolink_type}||{curie}||{preferred_name}||{name_pair[0]}||{name_pair[1]}\n"
-                    sapbertf.write(line)
-                    count_training_rows += 1
-
-                    # As long as the preferred name is shorter than the right size, we should add this clique to the
-                    # smaller file as well.
-                    if generate_smaller_file and is_preferred_name_short:
-                        generate_smaller_file.write(line)
-                        count_smaller_rows += 1
 
     logger.info(
         f"Converted {synonym_filename_gz} to SAPBERT training file {synonym_filename_gz}: "
@@ -142,7 +140,7 @@ def convert_synonyms_to_sapbert(synonym_filename_gz, sapbert_filename_gzipped):
     # Close SmallerFile if needed.
     if generate_smaller_file:
         generate_smaller_file.close()
-        percentage = count_smaller_rows / float(count_training_rows) * 100
+        percentage = count_smaller_rows / float(count_training_rows) * 100 if count_training_rows else 0
         logger.info(
             f"Converted {synonym_filename_gz} to smaller SAPBERT training file {generate_smaller_filename}: "
             + f"read {count_entry} entries and wrote out {count_smaller_rows} training rows ({percentage:.2f}%)."

--- a/src/exporters/sapbert.py
+++ b/src/exporters/sapbert.py
@@ -87,7 +87,7 @@ def convert_synonyms_to_sapbert(synonym_filename_gz, sapbert_filename_gzipped):
             names = entry.get("names", [])
             # Strip whitespace and drop empty strings if any
             names = [name.strip() for name in names if name.strip()]
-            
+
             if LOWERCASE_ALL_NAMES:
                 names = [name.lower() for name in names]
 

--- a/src/exporters/sapbert.py
+++ b/src/exporters/sapbert.py
@@ -114,14 +114,12 @@ def convert_synonyms_to_sapbert(synonym_filename_gz, sapbert_filename_gzipped):
                 if preferred_name_normalized == names[0]:
                     # no need to write the synonym pair if they are identical
                     continue
-                name_pairs = [(preferred_name_normalized, names[0])]                
+                name_pairs = [(preferred_name_normalized, names[0])]
             else:
                 name_pairs = list(itertools.combinations(set(names), 2))
 
-            name_pairs = [
-                name_pair for name_pair in name_pairs if (biolink_type, *sorted(name_pair)) not in seen_pairs
-            ]
-            
+            name_pairs = [name_pair for name_pair in name_pairs if (biolink_type, *sorted(name_pair)) not in seen_pairs]
+
             if len(name_pairs) > MAX_SYNONYM_PAIRS:
                 # Randomly select 50 pairs.
                 name_pairs = random.sample(name_pairs, MAX_SYNONYM_PAIRS)

--- a/src/exporters/sapbert.py
+++ b/src/exporters/sapbert.py
@@ -52,6 +52,40 @@ def pair_key(biolink_type, name_pair):
     return hash((biolink_type, *sorted(name_pair)))
 
 
+def sample_name_pairs(names, max_pairs):
+    """
+    Return up to max_pairs distinct pairs drawn from names, without building the full list of pairs
+    unless it is small.
+
+    A clique with n names has n*(n-1)/2 pairs, of which we keep at most max_pairs, so enumerating
+    them all is wasted work that grows quadratically with the size of the clique: today's largest
+    disease clique has 179 names, but nothing stops a conflated gene/protein clique from having
+    thousands. Above a few times max_pairs we therefore draw random pairs directly and reject
+    repeats, which needs a number of draws proportional to max_pairs rather than to n.
+
+    :param names: The distinct names to pair up, in a stable order.
+    :param max_pairs: The largest number of pairs to return.
+    :return: A list of up to max_pairs (name, name) tuples, each pair appearing at most once.
+    """
+    count_names = len(names)
+    total_pairs = count_names * (count_names - 1) // 2
+
+    # Rejection sampling only pays off when repeats are rare, and it slows to a crawl as the number
+    # of pairs we want approaches the number that exist. Below that point, enumerate them instead:
+    # the list is at most a few times max_pairs long, so it is cheap either way.
+    if total_pairs <= 4 * max_pairs:
+        name_pairs = list(itertools.combinations(names, 2))
+        if len(name_pairs) > max_pairs:
+            name_pairs = random.sample(name_pairs, max_pairs)
+        return name_pairs
+
+    index_pairs = set()
+    while len(index_pairs) < max_pairs:
+        first, second = sorted(random.sample(range(count_names), 2))
+        index_pairs.add((first, second))
+    return [(names[first], names[second]) for first, second in index_pairs]
+
+
 def convert_synonyms_to_sapbert(synonym_filename_gz, sapbert_filename_gzipped):
     """
     Convert a synonyms file to the training format for SAPBERT (https://github.com/RENCI-NER/sapbert).
@@ -145,13 +179,13 @@ def convert_synonyms_to_sapbert(synonym_filename_gz, sapbert_filename_gzipped):
                     continue
                 name_pairs = [(preferred_name_normalized, names[0])]
             else:
-                name_pairs = list(itertools.combinations(set(names), 2))
+                name_pairs = sample_name_pairs(sorted(set(names)), MAX_SYNONYM_PAIRS)
 
+            # Drop the pairs we have already written out. This happens after sampling rather than
+            # before it, since filtering first would mean enumerating every pair; an entry whose
+            # sampled pairs were mostly written out already contributes fewer than MAX_SYNONYM_PAIRS
+            # rows, which is what we want anyway.
             name_pairs = [name_pair for name_pair in name_pairs if pair_key(biolink_type, name_pair) not in seen_pairs]
-
-            if len(name_pairs) > MAX_SYNONYM_PAIRS:
-                # Randomly select 50 pairs.
-                name_pairs = random.sample(name_pairs, MAX_SYNONYM_PAIRS)
 
             for name_pair in name_pairs:
                 seen_pairs.add(pair_key(biolink_type, name_pair))

--- a/src/exporters/sapbert.py
+++ b/src/exporters/sapbert.py
@@ -30,6 +30,24 @@ MAX_SYNONYM_PAIRS = 50
 LOWERCASE_ALL_NAMES = True
 
 
+def pair_key(biolink_type, name_pair):
+    """
+    Return a 64-bit digest identifying a (Biolink type, name, name) triple, independent of the
+    order of the two names.
+
+    We remember digests rather than the names themselves because the set of pairs already written
+    grows with the size of the output: GeneProteinConflated has hundreds of millions of cliques, so
+    holding on to the name strings would need hundreds of gigabytes, while the digests need roughly
+    a fifth of that. At 64 bits, the chance of even a single collision across a billion pairs is
+    around 3%, and a collision costs us one redundant training row.
+
+    :param biolink_type: The Biolink type the pair was generated for (without the `biolink:` prefix).
+    :param name_pair: The two names making up this synonym pair.
+    :return: A hash of the type and the two names, in a canonical order.
+    """
+    return hash((biolink_type, *sorted(name_pair)))
+
+
 def convert_synonyms_to_sapbert(synonym_filename_gz, sapbert_filename_gzipped):
     """
     Convert a synonyms file to the training format for SAPBERT (https://github.com/RENCI-NER/sapbert).
@@ -62,6 +80,8 @@ def convert_synonyms_to_sapbert(synonym_filename_gz, sapbert_filename_gzipped):
     count_entry = 0
     count_training_rows = 0
     count_smaller_rows = 0
+    # Digests (see pair_key()) of the synonym pairs already written out, so that we only write each
+    # (Biolink type, name, name) triple once across the entire file.
     seen_pairs = set()
     with (
         gzip.open(synonym_filename_gz, "rt", encoding="utf-8") as synonymf,
@@ -96,6 +116,10 @@ def convert_synonyms_to_sapbert(synonym_filename_gz, sapbert_filename_gzipped):
             # confuse it up with our delimiter.
             names = [re.sub(r"\|\|+", "|", name) for name in names]
 
+            # The preferred name is written out as its own column, so it needs the same pipe cleanup
+            # as the names, or a label containing '||' would split into extra columns.
+            preferred_name = re.sub(r"\|\|+", "|", preferred_name)
+
             # Figure out the Biolink type to report.
             types = entry["types"]
             if len(types) == 0:
@@ -109,8 +133,9 @@ def convert_synonyms_to_sapbert(synonym_filename_gz, sapbert_filename_gzipped):
                 continue
             elif len(names) == 1:
                 # If we have less than two names, we don't have anything to randomize.
-                preferred_name_normalized = preferred_name.lower()
-                preferred_name_normalized = re.sub(r"\|\|+", "|", preferred_name_normalized)
+                # Normalize the preferred name the same way the names were normalized above, so the
+                # identity check compares like with like whatever LOWERCASE_ALL_NAMES is set to.
+                preferred_name_normalized = preferred_name.lower() if LOWERCASE_ALL_NAMES else preferred_name
                 if preferred_name_normalized == names[0]:
                     # no need to write the synonym pair if they are identical
                     continue
@@ -118,14 +143,14 @@ def convert_synonyms_to_sapbert(synonym_filename_gz, sapbert_filename_gzipped):
             else:
                 name_pairs = list(itertools.combinations(set(names), 2))
 
-            name_pairs = [name_pair for name_pair in name_pairs if (biolink_type, *sorted(name_pair)) not in seen_pairs]
+            name_pairs = [name_pair for name_pair in name_pairs if pair_key(biolink_type, name_pair) not in seen_pairs]
 
             if len(name_pairs) > MAX_SYNONYM_PAIRS:
                 # Randomly select 50 pairs.
                 name_pairs = random.sample(name_pairs, MAX_SYNONYM_PAIRS)
 
             for name_pair in name_pairs:
-                seen_pairs.add((biolink_type, *sorted(name_pair)))
+                seen_pairs.add(pair_key(biolink_type, name_pair))
                 line = f"biolink:{biolink_type}||{curie}||{preferred_name}||{name_pair[0]}||{name_pair[1]}\n"
                 sapbertf.write(line)
                 count_training_rows += 1

--- a/src/exporters/sapbert.py
+++ b/src/exporters/sapbert.py
@@ -24,7 +24,7 @@ logger = LoggingUtil.init_logging(__name__, level=logging.INFO)
 # Note that the smaller file is filtered out of the rows written to the full file, so a pair first
 # seen on a long-labelled clique is deduplicated away before any short-labelled clique can
 # contribute it to the smaller file. Turning this back on means giving the smaller file its own
-# set of seen pairs.
+# set of seen pairs (https://github.com/NCATSTranslator/Babel/issues/1057).
 GENERATE_DRUG_CHEMICAL_SMALLER_FILE = False
 # Limit DrugChemicalSmaller.txt.gz to terms that have a preferred name of 50 characters or more.
 DRUG_CHEMICAL_SMALLER_MAX_LABEL_LENGTH = 40

--- a/src/exporters/sapbert.py
+++ b/src/exporters/sapbert.py
@@ -30,6 +30,12 @@ GENERATE_DRUG_CHEMICAL_SMALLER_FILE = False
 DRUG_CHEMICAL_SMALLER_MAX_LABEL_LENGTH = 40
 # Include up to 50 synonym pairs for each synonym.
 MAX_SYNONYM_PAIRS = 50
+# When sampling those pairs out of a large clique (see sample_name_pairs()), how many random draws
+# are we willing to make per pair we want? Draws that repeat an earlier draw or land on a pair
+# already written out don't count towards MAX_SYNONYM_PAIRS, so without a budget a clique whose
+# pairs have nearly all been written out already would keep drawing to no purpose. Eight is enough
+# that reaching the budget means the clique has very few usable pairs left, not that we were unlucky.
+SYNONYM_PAIR_DRAWS_PER_PAIR = 8
 # Should we lowercase all the names?
 LOWERCASE_ALL_NAMES = True
 
@@ -52,10 +58,10 @@ def pair_key(biolink_type, name_pair):
     return hash((biolink_type, *sorted(name_pair)))
 
 
-def sample_name_pairs(names, max_pairs):
+def sample_name_pairs(names, max_pairs, biolink_type, seen_pairs):
     """
-    Return up to max_pairs distinct pairs drawn from names, without building the full list of pairs
-    unless it is small.
+    Return up to max_pairs distinct pairs of names that have not already been written out, without
+    building the full list of pairs unless it is small.
 
     A clique with n names has n*(n-1)/2 pairs, of which we keep at most max_pairs, so enumerating
     them all is wasted work that grows quadratically with the size of the clique: today's largest
@@ -63,27 +69,46 @@ def sample_name_pairs(names, max_pairs):
     thousands. Above a few times max_pairs we therefore draw random pairs directly and reject
     repeats, which needs a number of draws proportional to max_pairs rather than to n.
 
+    Since a drawn pair may turn out to have been written out already, drawing continues past the
+    rejected pairs until max_pairs of them survive or we run out of the draw budget (see
+    SYNONYM_PAIR_DRAWS_PER_PAIR) -- otherwise a clique overlapping heavily with an earlier one would
+    contribute fewer rows than a clique of the same size that happened to come first.
+
     :param names: The distinct names to pair up, in a stable order.
     :param max_pairs: The largest number of pairs to return.
+    :param biolink_type: The Biolink type this clique is being written out as.
+    :param seen_pairs: Digests (see pair_key()) of the pairs already written out, which are skipped.
     :return: A list of up to max_pairs (name, name) tuples, each pair appearing at most once.
     """
     count_names = len(names)
     total_pairs = count_names * (count_names - 1) // 2
 
-    # Rejection sampling only pays off when repeats are rare, and it slows to a crawl as the number
-    # of pairs we want approaches the number that exist. Below that point, enumerate them instead:
-    # the list is at most a few times max_pairs long, so it is cheap either way.
+    # Rejection sampling only pays off when repeat draws are rare, and it slows to a crawl as the
+    # number of pairs we want approaches the number that exist. Below that point, enumerate them
+    # instead: the list is at most a few times max_pairs long, so it is cheap either way.
     if total_pairs <= 4 * max_pairs:
-        name_pairs = list(itertools.combinations(names, 2))
+        name_pairs = [
+            name_pair
+            for name_pair in itertools.combinations(names, 2)
+            if pair_key(biolink_type, name_pair) not in seen_pairs
+        ]
         if len(name_pairs) > max_pairs:
             name_pairs = random.sample(name_pairs, max_pairs)
         return name_pairs
 
-    index_pairs = set()
-    while len(index_pairs) < max_pairs:
-        first, second = sorted(random.sample(range(count_names), 2))
-        index_pairs.add((first, second))
-    return [(names[first], names[second]) for first, second in index_pairs]
+    drawn_indices = set()
+    name_pairs = []
+    for _ in range(SYNONYM_PAIR_DRAWS_PER_PAIR * max_pairs):
+        if len(name_pairs) >= max_pairs:
+            break
+        index_pair = tuple(sorted(random.sample(range(count_names), 2)))
+        if index_pair in drawn_indices:
+            continue
+        drawn_indices.add(index_pair)
+        name_pair = (names[index_pair[0]], names[index_pair[1]])
+        if pair_key(biolink_type, name_pair) not in seen_pairs:
+            name_pairs.append(name_pair)
+    return name_pairs
 
 
 def convert_synonyms_to_sapbert(synonym_filename_gz, sapbert_filename_gzipped):
@@ -177,15 +202,12 @@ def convert_synonyms_to_sapbert(synonym_filename_gz, sapbert_filename_gzipped):
                 if preferred_name_normalized == names[0]:
                     # no need to write the synonym pair if they are identical
                     continue
-                name_pairs = [(preferred_name_normalized, names[0])]
+                name_pair = (preferred_name_normalized, names[0])
+                # Skip the pair if we have already written it out for this Biolink type.
+                name_pairs = [] if pair_key(biolink_type, name_pair) in seen_pairs else [name_pair]
             else:
-                name_pairs = sample_name_pairs(sorted(set(names)), MAX_SYNONYM_PAIRS)
-
-            # Drop the pairs we have already written out. This happens after sampling rather than
-            # before it, since filtering first would mean enumerating every pair; an entry whose
-            # sampled pairs were mostly written out already contributes fewer than MAX_SYNONYM_PAIRS
-            # rows, which is what we want anyway.
-            name_pairs = [name_pair for name_pair in name_pairs if pair_key(biolink_type, name_pair) not in seen_pairs]
+                # sample_name_pairs() applies the same already-written check as it draws.
+                name_pairs = sample_name_pairs(sorted(set(names)), MAX_SYNONYM_PAIRS, biolink_type, seen_pairs)
 
             for name_pair in name_pairs:
                 seen_pairs.add(pair_key(biolink_type, name_pair))

--- a/src/exporters/sapbert.py
+++ b/src/exporters/sapbert.py
@@ -133,7 +133,7 @@ def convert_synonyms_to_sapbert(synonym_filename_gz, sapbert_filename_gzipped):
 
             # How many names do we have?
             if len(names) == 0:
-                # This shouldn't happen, but let's anticipate this anyway.
+                # Not useful for training, so let's skip it.
                 continue
             elif len(names) == 1:
                 # If we have less than two names, we don't have anything to randomize.

--- a/src/exporters/sapbert.py
+++ b/src/exporters/sapbert.py
@@ -21,6 +21,10 @@ logger = LoggingUtil.init_logging(__name__, level=logging.INFO)
 
 # Configuration options
 # Should we generate a DrugChemicalSmaller.txt.gz file at all?
+# Note that the smaller file is filtered out of the rows written to the full file, so a pair first
+# seen on a long-labelled clique is deduplicated away before any short-labelled clique can
+# contribute it to the smaller file. Turning this back on means giving the smaller file its own
+# set of seen pairs.
 GENERATE_DRUG_CHEMICAL_SMALLER_FILE = False
 # Limit DrugChemicalSmaller.txt.gz to terms that have a preferred name of 50 characters or more.
 DRUG_CHEMICAL_SMALLER_MAX_LABEL_LENGTH = 40

--- a/src/exporters/sapbert.py
+++ b/src/exporters/sapbert.py
@@ -49,7 +49,7 @@ def pair_key(biolink_type, name_pair):
     grows with the size of the output: GeneProteinConflated has hundreds of millions of cliques, so
     holding on to the name strings would need hundreds of gigabytes, while the digests need roughly
     a fifth of that. At 64 bits, the chance of even a single collision across a billion pairs is
-    around 3%, and a collision costs us one redundant training row.
+    around 3%, and a collision costs us one correct training row.
 
     :param biolink_type: The Biolink type the pair was generated for (without the `biolink:` prefix).
     :param name_pair: The two names making up this synonym pair.

--- a/src/snakefiles/exports.snakefile
+++ b/src/snakefiles/exports.snakefile
@@ -72,5 +72,10 @@ rule generate_sapbert_training_data:
     resources:
         # Slowest of the 18 wildcard instances on 2026jul22 was GeneProteinConflated at 1.9h.
         runtime="3h",
+        # The exporter remembers a digest of every synonym pair it writes so it can skip duplicates,
+        # so memory grows with the size of the output: GeneProteinConflated is the worst case at
+        # roughly 300M pairs x ~95 bytes per set entry. Recheck against the benchmark TSVs after the
+        # first run that includes the deduplication (see docs/tools/Resources.md).
+        mem="64G",
     run:
         sapbert.convert_synonyms_to_sapbert(input.synonym_file_gz, output.sapbert_training_data_file)

--- a/tests/test_sapbert_exporter.py
+++ b/tests/test_sapbert_exporter.py
@@ -88,3 +88,41 @@ def test_convert_synonyms_to_sapbert_deduplicates_after_normalization(tmp_path):
     assert len(rows) == 1
     assert rows[0][:3] == ["biolink:NamedThing", "EXAMPLE:1", "Example Label"]
     assert set(rows[0][3:]) == {"alpha|beta", "gamma"}
+
+
+@pytest.mark.unit
+def test_convert_synonyms_to_sapbert_deduplicates_pairs_within_biolink_type(tmp_path):
+    """The same normalized name pair should be written once per Biolink type across the output file."""
+    synonym_file = tmp_path / "Mixed.txt.gz"
+    sapbert_file = tmp_path / "sapbert" / "Mixed.txt.gz"
+    _write_synonyms(
+        synonym_file,
+        [
+            {
+                "curie": "MONDO:0000001",
+                "preferred_name": "Disease One",
+                "names": ["shared one", "shared two"],
+                "types": ["Disease"],
+            },
+            {
+                "curie": "MONDO:0000002",
+                "preferred_name": "Disease Two",
+                "names": ["shared two", "shared one"],
+                "types": ["Disease"],
+            },
+            {
+                "curie": "HP:0000001",
+                "preferred_name": "Phenotype One",
+                "names": ["shared one", "shared two"],
+                "types": ["PhenotypicFeature"],
+            },
+        ],
+    )
+
+    convert_synonyms_to_sapbert(str(synonym_file), str(sapbert_file))
+
+    rows = _read_sapbert_rows(sapbert_file)
+    assert len(rows) == 2
+    assert rows[0][:3] == ["biolink:Disease", "MONDO:0000001", "Disease One"]
+    assert rows[1][:3] == ["biolink:PhenotypicFeature", "HP:0000001", "Phenotype One"]
+    assert {frozenset(row[3:]) for row in rows} == {frozenset({"shared one", "shared two"})}

--- a/tests/test_sapbert_exporter.py
+++ b/tests/test_sapbert_exporter.py
@@ -1,0 +1,90 @@
+"""Tests for SAPBERT training-data export."""
+
+import gzip
+import json
+
+import pytest
+
+from src.exporters.sapbert import convert_synonyms_to_sapbert
+
+
+def _write_synonyms(path, entries):
+    with gzip.open(path, "wt", encoding="utf-8") as output:
+        for entry in entries:
+            output.write(json.dumps(entry) + "\n")
+
+
+def _read_sapbert_rows(path):
+    with gzip.open(path, "rt", encoding="utf-8") as output:
+        return [line.rstrip("\n").split("||") for line in output]
+
+
+@pytest.mark.unit
+def test_convert_synonyms_to_sapbert_skips_singleton_preferred_name_pair(tmp_path):
+    """A CellLine-style entry whose only name equals its preferred name should not emit term||term."""
+    synonym_file = tmp_path / "CellLine.txt.gz"
+    sapbert_file = tmp_path / "sapbert" / "CellLine.txt.gz"
+    _write_synonyms(
+        synonym_file,
+        [
+            {
+                "curie": "CLO:0022591",
+                "preferred_name": "GM12814 cell",
+                "names": ["GM12814 cell"],
+                "types": ["CellLine"],
+            }
+        ],
+    )
+
+    convert_synonyms_to_sapbert(str(synonym_file), str(sapbert_file))
+
+    assert _read_sapbert_rows(sapbert_file) == []
+
+
+@pytest.mark.unit
+def test_convert_synonyms_to_sapbert_keeps_singleton_distinct_from_preferred_name(tmp_path):
+    """A one-name entry should still emit a row when the synonym differs from the preferred name."""
+    synonym_file = tmp_path / "Disease.txt.gz"
+    sapbert_file = tmp_path / "sapbert" / "Disease.txt.gz"
+    _write_synonyms(
+        synonym_file,
+        [
+            {
+                "curie": "MONDO:0000001",
+                "preferred_name": "Preferred Label",
+                "names": ["alternate label"],
+                "types": ["Disease"],
+            }
+        ],
+    )
+
+    convert_synonyms_to_sapbert(str(synonym_file), str(sapbert_file))
+
+    assert _read_sapbert_rows(sapbert_file) == [
+        ["biolink:Disease", "MONDO:0000001", "Preferred Label", "preferred label", "alternate label"]
+    ]
+
+
+@pytest.mark.unit
+def test_convert_synonyms_to_sapbert_deduplicates_after_normalization(tmp_path):
+    """Names that collapse after lowercasing and pipe cleanup should only contribute distinct pairs."""
+    synonym_file = tmp_path / "Example.txt.gz"
+    sapbert_file = tmp_path / "sapbert" / "Example.txt.gz"
+    _write_synonyms(
+        synonym_file,
+        [
+            {
+                "curie": "EXAMPLE:1",
+                "preferred_name": "Example Label",
+                "names": ["Alpha||Beta", "alpha|beta", "Gamma"],
+                "types": ["NamedThing"],
+            }
+        ],
+    )
+
+    convert_synonyms_to_sapbert(str(synonym_file), str(sapbert_file))
+
+    rows = _read_sapbert_rows(sapbert_file)
+    assert len(rows) == 1
+    assert rows[0][:3] == ["biolink:NamedThing", "EXAMPLE:1", "Example Label"]
+    assert set(rows[0][3:]) == {"alpha|beta", "gamma"}

--- a/tests/test_sapbert_exporter.py
+++ b/tests/test_sapbert_exporter.py
@@ -1,6 +1,7 @@
 """Tests for SAPBERT training-data export."""
 
 import gzip
+import itertools
 import json
 
 import pytest
@@ -175,3 +176,28 @@ def test_convert_synonyms_to_sapbert_deduplicates_pairs_within_biolink_type(tmp_
     assert rows[0][:3] == ["biolink:Disease", "MONDO:0000001", "Disease One"]
     assert rows[1][:3] == ["biolink:PhenotypicFeature", "HP:0000001", "Phenotype One"]
     assert {frozenset(row[3:]) for row in rows} == {frozenset({"shared one", "shared two"})}
+
+
+# SYNONYM PAIR SAMPLING
+
+
+@pytest.mark.unit
+def test_sample_name_pairs_returns_every_pair_when_under_the_cap():
+    """A clique with fewer pairs than the cap should contribute all of them."""
+    names = ["a", "b", "c", "d"]
+    assert sorted(sapbert.sample_name_pairs(names, 50)) == sorted(itertools.combinations(names, 2))
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("count_names", [12, 40, 500])
+def test_sample_name_pairs_samples_distinct_pairs_over_the_cap(count_names):
+    """Above the cap, both the enumerating and the rejection-sampling branch return distinct real pairs."""
+    names = [f"name {i}" for i in range(count_names)]
+    name_pairs = sapbert.sample_name_pairs(names, 50)
+
+    assert len(name_pairs) == 50
+    assert len({tuple(sorted(name_pair)) for name_pair in name_pairs}) == 50
+    for first, second in name_pairs:
+        assert first in names
+        assert second in names
+        assert first != second

--- a/tests/test_sapbert_exporter.py
+++ b/tests/test_sapbert_exporter.py
@@ -185,7 +185,7 @@ def test_convert_synonyms_to_sapbert_deduplicates_pairs_within_biolink_type(tmp_
 def test_sample_name_pairs_returns_every_pair_when_under_the_cap():
     """A clique with fewer pairs than the cap should contribute all of them."""
     names = ["a", "b", "c", "d"]
-    assert sorted(sapbert.sample_name_pairs(names, 50)) == sorted(itertools.combinations(names, 2))
+    assert sorted(sapbert.sample_name_pairs(names, 50, "Disease", set())) == sorted(itertools.combinations(names, 2))
 
 
 @pytest.mark.unit
@@ -193,7 +193,7 @@ def test_sample_name_pairs_returns_every_pair_when_under_the_cap():
 def test_sample_name_pairs_samples_distinct_pairs_over_the_cap(count_names):
     """Above the cap, both the enumerating and the rejection-sampling branch return distinct real pairs."""
     names = [f"name {i}" for i in range(count_names)]
-    name_pairs = sapbert.sample_name_pairs(names, 50)
+    name_pairs = sapbert.sample_name_pairs(names, 50, "Disease", set())
 
     assert len(name_pairs) == 50
     assert len({tuple(sorted(name_pair)) for name_pair in name_pairs}) == 50
@@ -201,3 +201,32 @@ def test_sample_name_pairs_samples_distinct_pairs_over_the_cap(count_names):
         assert first in names
         assert second in names
         assert first != second
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("count_names", [12, 40, 500])
+def test_sample_name_pairs_keeps_drawing_past_already_written_pairs(count_names):
+    """A clique overlapping an earlier one should still fill the cap, not stop short at rejected draws."""
+    names = [f"name {i}" for i in range(count_names)]
+    # Mark four fifths of the clique's pairs as already written out.
+    all_pairs = list(itertools.combinations(names, 2))
+    seen_pairs = {sapbert.pair_key("Disease", pair) for pair in all_pairs[: len(all_pairs) * 4 // 5]}
+
+    name_pairs = sapbert.sample_name_pairs(names, 50, "Disease", seen_pairs)
+
+    # A 12-name clique has only 14 unwritten pairs left to give; the larger two can fill the cap.
+    assert len(name_pairs) == min(50, len(all_pairs) - len(seen_pairs))
+    assert not [pair for pair in name_pairs if sapbert.pair_key("Disease", pair) in seen_pairs]
+
+
+@pytest.mark.unit
+def test_sample_name_pairs_gives_up_when_almost_every_pair_is_written():
+    """When the draw budget runs out, the sampler should return what it found rather than spin."""
+    names = [f"name {i}" for i in range(500)]
+    all_pairs = list(itertools.combinations(names, 2))
+    # Leave a single pair undrawn: 8 * 50 draws out of 124,750 pairs will almost never find it.
+    seen_pairs = {sapbert.pair_key("Disease", pair) for pair in all_pairs[1:]}
+
+    name_pairs = sapbert.sample_name_pairs(names, 50, "Disease", seen_pairs)
+
+    assert len(name_pairs) < 50

--- a/tests/test_sapbert_exporter.py
+++ b/tests/test_sapbert_exporter.py
@@ -5,6 +5,7 @@ import json
 
 import pytest
 
+from src.exporters import sapbert
 from src.exporters.sapbert import convert_synonyms_to_sapbert
 
 
@@ -88,6 +89,54 @@ def test_convert_synonyms_to_sapbert_deduplicates_after_normalization(tmp_path):
     assert len(rows) == 1
     assert rows[0][:3] == ["biolink:NamedThing", "EXAMPLE:1", "Example Label"]
     assert set(rows[0][3:]) == {"alpha|beta", "gamma"}
+
+
+@pytest.mark.unit
+def test_convert_synonyms_to_sapbert_skips_singleton_pair_without_lowercasing(tmp_path, monkeypatch):
+    """With LOWERCASE_ALL_NAMES off, a lone name identical to the preferred name should still be dropped."""
+    monkeypatch.setattr(sapbert, "LOWERCASE_ALL_NAMES", False)
+    synonym_file = tmp_path / "CellLine.txt.gz"
+    sapbert_file = tmp_path / "sapbert" / "CellLine.txt.gz"
+    _write_synonyms(
+        synonym_file,
+        [
+            {
+                "curie": "CLO:0022591",
+                "preferred_name": "GM12814 cell",
+                "names": ["GM12814 cell"],
+                "types": ["CellLine"],
+            }
+        ],
+    )
+
+    convert_synonyms_to_sapbert(str(synonym_file), str(sapbert_file))
+
+    assert _read_sapbert_rows(sapbert_file) == []
+
+
+@pytest.mark.unit
+def test_convert_synonyms_to_sapbert_cleans_pipes_in_preferred_name(tmp_path):
+    """A preferred name containing '||' should be collapsed to a single pipe so the row keeps five columns."""
+    synonym_file = tmp_path / "Example.txt.gz"
+    sapbert_file = tmp_path / "sapbert" / "Example.txt.gz"
+    _write_synonyms(
+        synonym_file,
+        [
+            {
+                "curie": "EXAMPLE:2",
+                "preferred_name": "Alpha||Beta",
+                "names": ["one", "two"],
+                "types": ["NamedThing"],
+            }
+        ],
+    )
+
+    convert_synonyms_to_sapbert(str(synonym_file), str(sapbert_file))
+
+    rows = _read_sapbert_rows(sapbert_file)
+    assert len(rows) == 1
+    assert rows[0][:3] == ["biolink:NamedThing", "EXAMPLE:2", "Alpha|Beta"]
+    assert set(rows[0][3:]) == {"one", "two"}
 
 
 @pytest.mark.unit


### PR DESCRIPTION
This PR should fix the identical synonym pair issue detailed in #1011 as well as deduplication of synonym pairs within the same biolink type. Closes #1011.