### PR TITLE
Fix the preferred-name issue template's BabelTest to use HasLabel

### DIFF
--- a/.github/ISSUE_TEMPLATE/bad-preferred-name.yml
+++ b/.github/ISSUE_TEMPLATE/bad-preferred-name.yml
@@ -69,7 +69,7 @@ body:
         You can add multiple entries, one per line.
         See [available BabelTest formats](https://github.com/NCATSTranslator/Babel/blob/main/docs/Triage.md#adding-automated-tests-to-issues).
       render: text
-      value: "{{BabelTest|HasPreferredName|curie|correct}}"
+      value: "{{BabelTest|HasLabel|curie|correct}}"
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
The "Bad, incorrect or unclear preferred name" issue form pre-fills its optional BabelTest field with `{{BabelTest|HasPreferredName|curie|correct}}`. There is no `haspreferredname` in babel-validation's `ASSERTION_HANDLERS` — the assertion that checks a clique's preferred label is `HasLabel`, and it takes the same two parameters (CURIE, then the expected label) in the same order. `docs/Triage.md` has always documented `HasLabel`; only the template was wrong.

This is worth fixing rather than leaving: an unknown assertion type is a hard `pytest.fail` in `tests/github_issues/test_github_issues.py`, regardless of whether the issue is open or closed. Unlike a failing-but-valid assertion on an open issue — which is an expected `xfail` — the first issue filed from this template with the default left in place would have turned the whole babel-validation GitHub-issues suite red. Nothing is broken today only because no issue has used this template's BabelTest field yet.

Found while preparing a Babel hackathon session on adding BabelTest assertions to existing issues, where this template is one of the things participants copy from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
