### PR TITLE
Ingest ChEBI's structure values and role assertions into the property store

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,15 @@ canonical prefix-constant registry; its `id_prefixes` order in the Biolink Model
   `compendia/umls.txt` so its label survives downstream. Manual Biolink-type override tables and
   their drift test: [`docs/sources/CLAUDE.md`](docs/sources/CLAUDE.md) and
   `docs/sources/UMLS/Leftover.md`.
+- **Properties** — `src/properties.py` holds node/clique annotations as `Property(curie, predicate,
+  value, source)`, written as gzipped JSONL under `intermediate/<pipeline>/properties/` and swept
+  into `Property.parquet` by the DuckDB export. `supported_predicates` is the only validation gate,
+  so a new property means adding its URI there and in `src/predicates.py`. Two rules: a property
+  file is only loaded into `write_compendium()`'s in-memory `PropertyList` if a rule passes it as
+  `properties_jsonl_gz_files`, so keep annotations nothing consumes yet in their *own* file (ChEBI
+  structure and roles do); and name a predicate after the vocabulary that publishes it rather than
+  minting a Babel URI. Properties are annotations, never equivalences — nothing here reaches
+  `glom()`. See `docs/sources/CHEBI/README.md` and `docs/sources/CHEBI/roles/README.md`.
 - **DuckDB export** — `src/snakefiles/duckdb.snakefile` builds a queryable DuckDB database
   (`Node`/`Clique`/`Edge`/`Conflation`) alongside the JSONL compendia (schema in
   `docs/DataFormats.md`); its `Edge` table answers "which clique contains CURIE X" in one query

--- a/docs/DataFormats.md
+++ b/docs/DataFormats.md
@@ -318,10 +318,10 @@ Derived from the conflation JSONL files (`GeneProtein.txt`, `DrugChemical.txt`).
 | curie              | STRING | A member CURIE of the conflation group               |
 | curie_prefix       | STRING | Prefix of the member CURIE                           |
 
-### Intermediate tables (`Concord.parquet`, `Identifier.parquet`, `Metadata.parquet`)
+### Intermediate tables (`Concord.parquet`, `Identifier.parquet`, `Metadata.parquet`, `Property.parquet`)
 
-Unlike the tables above, these three are not per-semantic-type; they sweep the whole
-`babel_outputs/intermediate/` tree into three flat Parquet files written directly under
+Unlike the tables above, these four are not per-semantic-type; they sweep the whole
+`babel_outputs/intermediate/` tree into four flat Parquet files written directly under
 `babel_outputs/duckdb/` (not under `parquet/filename={Type}/`). They are produced by
 `export_intermediates_to_parquet()` (rule `export_intermediate_files_to_duckdb`) and make the raw
 build inputs — the cross-reference concords and per-source identifier lists — queryable without
@@ -373,6 +373,34 @@ table exists to describe the concord and identifier files above:
 | subject_filename  | STRING | The file the metadata describes (the `<subject>` of a sidecar, or the metadata file's own name for a bare `metadata.yaml`) |
 | subject_file_path | STRING | Absolute path of the described file (or its directory, for a bare `metadata.yaml`) |
 | metadata_json     | STRING | The metadata YAML contents                                          |
+
+`Property.parquet` — one row per property, from every non-empty file in a `properties/` directory.
+Property files are gzipped JSONL of `src.properties.Property`, so unlike the concord and ids files
+their columns are fixed rather than sniffed:
+
+| Column    | Type   | Meaning                                                                    |
+|-----------|--------|----------------------------------------------------------------------------|
+| filename  | STRING | Absolute path of the property file this row came from                      |
+| curie     | STRING | The CURIE the property is about, e.g. `CHEBI:15365`                        |
+| predicate | STRING | The property URI, e.g. `https://w3id.org/chemrof/generalized_empirical_formula` |
+| value     | STRING | The property value, e.g. `C9H8O4`. Always a single string — a CURIE with several values for one predicate has several rows |
+| source    | STRING | Free text saying where the value came from                                 |
+
+Properties are annotations, not equivalences: nothing here took part in clique building, and most
+of it does not appear in the compendia at all. This table is how you ask a structure question of a
+build without one:
+
+```sql
+-- What structure does ChEBI record for aspirin?
+SELECT predicate, value FROM read_parquet('babel_outputs/duckdb/Property.parquet')
+WHERE curie = 'CHEBI:15365';
+
+-- Which cliques were split apart despite sharing an InChIKey skeleton? (issues #452, #230)
+SELECT split_part(value, '-', 1) AS skeleton, count(DISTINCT curie) AS chemicals
+FROM read_parquet('babel_outputs/duckdb/Property.parquet')
+WHERE predicate = 'https://w3id.org/chemrof/inchi_key_string'
+GROUP BY 1 HAVING count(DISTINCT curie) > 1;
+```
 
 Labels are intentionally not exported here: `ids/` files carry only `CURIE\tbiolink:Type`, and the
 label for any identifier that landed in a clique is already available in `Node.parquet` (join

--- a/docs/sources/CHEBI/README.md
+++ b/docs/sources/CHEBI/README.md
@@ -3,9 +3,10 @@
 ChEBI is ingested from two files pulled by `src/datahandlers/chebi.py`:
 
 - `ChEBI_complete.sdf` — the structure file, read by `make_chebi_relations()` for secondary
-  identifiers and KEGG COMPOUND / PubChem Compound cross-references. (Labels come from the OBO
-  ontology via UberGraph, not from here; the SDF's `ChEBI NAME` tag is read only as a canary — see
-  `CHEBI_SDF_KEYS`.)
+  identifiers, KEGG COMPOUND / PubChem Compound cross-references, and the structure and
+  physical-property values described under [Structure properties](#structure-properties) below.
+  (Labels come from the OBO ontology via UberGraph, not from here; the SDF's `ChEBI NAME` tag is
+  read only as a canary — see `CHEBI_SDF_KEYS`.)
 - `database_accession.tsv` — the flat cross-reference table, covering the ChEBI entries that have no
   structure and so never appear in the SDF.
 - `source.tsv` and `status.tsv` — the lookup tables that turn `database_accession.tsv`'s numeric
@@ -95,6 +96,56 @@ Neither `check_chebi_sdf_keys()` nor the `count_xrefs` guard could catch it, bec
 supplies ~197,000 xrefs on its own — a reminder that a whole-output emptiness check does not protect
 an individual input. `make_chebi_relations()` now counts this file's contribution separately from
 the SDF's and raises if it is zero, which is what would have caught this the release it appeared.
+
+## Structure properties
+
+`make_chebi_relations()` also writes the SDF's structure and physical-property values to
+`intermediate/chemicals/properties/chebi_structure.jsonl.gz`, one `Property` row per
+(ChEBI, predicate, value):
+
+| SDF tag | Predicate | Rows, 2026-06-29 |
+| --- | --- | ---: |
+| `SMILES` | `chemrof:smiles_string` | 192,445 |
+| `FORMULA` | `chemrof:generalized_empirical_formula` | 192,383 |
+| `MONOISOTOPIC_MASS` | `chemrof:monoisotopic_mass` | 192,256 |
+| `MASS` | `chemrof:mass` | 192,249 |
+| `INCHI` | `chemrof:inchi_string` | 181,048 |
+| `INCHIKEY` | `chemrof:inchi_key_string` | 181,048 |
+| `CHARGE` | `chemrof:charge` | 15,613 |
+
+These are annotations, not equivalences: they are written to their own file, are not an input to
+`chemical_compendia`, and take no part in concord or clique building. `make_chebi_relations()`'s
+docstring explains why they are kept out of `get_chebi_concord.jsonl.gz`, which *is* loaded into
+`write_compendium()`'s in-memory `PropertyList`.
+
+The predicates are ChemROF's rather than ChEBI's own `obo/chebi/` annotation properties, because
+that is the namespace UberGraph now publishes these values under — see
+[#1086](https://github.com/NCATSTranslator/Babel/issues/1086), where reading them under the old
+names is silently returning nothing.
+
+### Semicolons in an InChI are not separators
+
+Multi-valued SDF tags are semicolon-delimited, and `split_chebi_sdf_values()` exists to split them.
+**Structure values must not go through it.** A multi-component InChI uses `;` to separate
+per-component layers: [`CHEBI:29124`](http://purl.obolibrary.org/obo/CHEBI_29124)
+"dioxouranium(1+)" is `InChI=1S/2O.U/q;;+1`. 3,997 of the 181,048 InChIs in the 2026-06-29 SDF
+contain one, so splitting would shred all of them into fragments that are not InChIs — the same
+shape as the NCBIGene double-prime bug, where a plausible cleanup discarded ~4,000 real values.
+Every tag in `CHEBI_SDF_STRUCTURE_PROPERTIES` is single-valued, so the lines are joined and used
+as-is. `tests/data/chebi_dioxouranium.sdf` pins this.
+
+### CHARGE is exempt from the empty-input guard
+
+`make_chebi_relations()` raises if any input it reads produces no rows, which is what catches a
+value-format change that a tag-name check cannot see. `CHARGE` is deliberately excluded
+(`CHEBI_SDF_SPARSE_STRUCTURE_KEYS`): it is on 8% of entries because most ChEBI entries are
+uncharged and simply omit it, so guarding it would be a check that fires on legitimate data. A
+`CHARGE` *rename* is still caught by `check_chebi_sdf_keys()`.
+
+## Roles
+
+ChEBI's `RO:0000087` "has role" assertions are ingested separately, by `make_chebi_roles()` via
+UberGraph. See [`roles/README.md`](./roles/README.md).
 
 ## Deliberately ignored: PubChem substance xrefs
 

--- a/docs/sources/CHEBI/roles/README.md
+++ b/docs/sources/CHEBI/roles/README.md
@@ -1,0 +1,70 @@
+# ChEBI roles
+
+ChEBI asserts what a chemical *does* — its role — separately from what it *is*. Aspirin
+([`CHEBI:15365`](http://purl.obolibrary.org/obo/CHEBI_15365) "acetylsalicylic acid") is a
+salicylate by structure and, by role, a cyclooxygenase inhibitor, an antipyretic, a
+teratogenic agent and ten other things. `make_chebi_roles()` records those assertions as
+properties.
+
+## What is collected
+
+Every [`RO:0000087`](http://purl.obolibrary.org/obo/RO_0000087) "has role" assertion on a
+descendant of [`CHEBI:24431`](http://purl.obolibrary.org/obo/CHEBI_24431) "chemical entity", written
+to `intermediate/chemicals/properties/chebi_roles.jsonl.gz` as
+`Property(curie=<chemical>, predicate=RO:0000087, value=<role>)`.
+
+These are annotations, not equivalences. They are deliberately **not** an input to
+`chemical_compendia`, so they take no part in concord building, `glom()` or typing — see
+`make_chebi_roles()`'s docstring for why they also sit in their own file rather than in
+`get_chebi_concord.jsonl.gz`.
+
+## The non-redundant graph, and why
+
+UberGraph publishes role assertions in both its redundant and non-redundant graphs. We query the
+**non-redundant** one, so each chemical carries only its directly asserted roles. Aspirin has 13
+there against 45 in the redundant graph; the extra 32 are the ancestors of those 13
+(`EC 1.14.99.1 (prostaglandin-endoperoxide synthase) inhibitor` implies
+`EC 1.14.* ... inhibitor` implies `EC 1.* (oxidoreductase) inhibitor`, and so on). Storing the
+closure would multiply the row count several-fold to say nothing new. A consumer that wants
+ancestors can walk the role hierarchy itself.
+
+## The roles are not themselves normalized
+
+The values are ChEBI CURIEs that Babel does not currently give cliques of their own. Role terms sit
+under [`CHEBI:50906`](http://purl.obolibrary.org/obo/CHEBI_50906) "role", which is a separate ChEBI
+root — it is *not* a descendant of `CHEBI:24431` — so `write_chebi_ids()` never gives them a row in
+`ids/CHEBI`, and no role term appears as a *subject* in this file.
+
+Some of them nevertheless reach `ChemicalEntity.txt` today, as passengers: MeSH's D-tree is typed
+`biolink:ChemicalEntity` wholesale, and a MeSH↔ChEBI concord pulls the ChEBI role term into that
+clique. [`CHEBI:35482`](http://purl.obolibrary.org/obo/CHEBI_35482) "opioid analgesic" normalizes
+today as a `biolink:ChemicalEntity` clique with `MESH:D000701` and `UMLS:C0002772`.
+
+Typing them properly — Biolink has a `biolink:ChemicalRole` class with `id_prefixes: ['CHEBI']` — is
+[#101](https://github.com/NCATSTranslator/Babel/issues/101), and the UMLS side of the same question
+is [#390](https://github.com/NCATSTranslator/Babel/issues/390). Both change existing cliques, which
+this ingest does not.
+
+## Re-auditing
+
+[`scripts/audit_chebi_roles.py`](./scripts/audit_chebi_roles.py) ranks roles by how many chemicals
+carry them. It imports `CHEBI_ROLE_ROOT` and `HAS_ROLE` from the production module, so the audit
+cannot drift from the ingest.
+
+```bash
+uv run python docs/sources/CHEBI/roles/scripts/audit_chebi_roles.py \
+    babel_outputs/intermediate/chemicals/properties/chebi_roles.jsonl.gz \
+    babel_downloads/CHEBI/labels
+```
+
+[`role_audit.md`](./role_audit.md) is its output for the 2026-06-29 ChEBI download — 42,918 role
+assertions over 24,807 chemicals and 1,377 distinct roles — with the full per-role ranking in
+[`role_counts.csv`](./role_counts.csv).
+
+## The guard
+
+`make_chebi_roles()` raises if UberGraph returns no role assertions at all. A SPARQL query against a
+renamed predicate returns an empty result set rather than an error, which is how the `CHEBIP:smiles`
+lookup in `get_subclasses_and_smiles()` went quiet for ~194,000 terms
+([#1086](https://github.com/NCATSTranslator/Babel/issues/1086)). ChEBI curates tens of thousands of
+role assertions, so zero means the query is broken, not that the source is empty.

--- a/docs/sources/CHEBI/roles/role_audit.md
+++ b/docs/sources/CHEBI/roles/role_audit.md
@@ -1,0 +1,41 @@
+# ChEBI role audit
+
+Source file: `babel_outputs/intermediate/chemicals/properties/chebi_roles.jsonl.gz`
+
+Roles are collected for descendants of `CHEBI:24431` "chemical entity".
+
+- Role assertions: 42,918
+- Chemicals carrying at least one role: 24,807
+- Distinct roles: 1,377
+
+## The 25 most-used roles
+
+Full ranking in [`role_counts.csv`](./role_counts.csv).
+
+| Role | Chemicals | Examples |
+| --- | ---: | --- |
+| `CHEBI:25212` "metabolite" | 4,546 | `CHEBI:10017` "volemitol", `CHEBI:66979` "phosphatidylcholine 44:0", `CHEBI:70328` "guttiferone E" |
+| `CHEBI:76924` "plant metabolite" | 3,127 | `CHEBI:10038` "wighteone", `CHEBI:26718` "solanesol", `CHEBI:68124` "3S-hydrangenol 4'-O-alpha-L-rhamnopyranoysl-(1->3)-beta-D-glucopyranoside" |
+| `CHEBI:35610` "antineoplastic agent" | 1,976 | `CHEBI:10037` "wedelolactone", `CHEBI:46319` "6-azauridine 5'-monophosphate", `CHEBI:66691` "melophlin P" |
+| `CHEBI:77746` "human metabolite" | 1,955 | `CHEBI:10224` "alpha-cubebene", `CHEBI:188253` "(10Z)-tricosene", `CHEBI:57667` "dADP(3-)" |
+| `CHEBI:75771` "mouse metabolite" | 1,550 | `CHEBI:10329` "alpha-ribazole", `CHEBI:17189` "2,5-dihydroxybenzoic acid", `CHEBI:33998` "(1R,2S)-naphthalene 1,2-oxide" |
+| `CHEBI:76969` "bacterial metabolite" | 989 | `CHEBI:111542` "validone", `CHEBI:229570` "subrutilene D", `CHEBI:77350` "neopikromycin(1+)" |
+| `CHEBI:75772` "Saccharomyces cerevisiae metabolite" | 760 | `CHEBI:1109` "2-hexaprenyl-6-methoxyphenol", `CHEBI:27809` "L-4-hydroxyglutamic semialdehyde", `CHEBI:57328` "3'-dephospho-CoA(2-)" |
+| `CHEBI:53000` "epitope" | 686 | `CHEBI:12357` "beta-D-galactosyl-(1->4)-N-acetyl-beta-D-glucosaminyl group", `CHEBI:59216` "beta-D-Galp-(1->3)-beta-D-GalpNAc-(1->4)-beta-D-Galp-(1->4)-beta-D-Glcp", `CHEBI:68680` "beta-D-Galp-(1->3)-beta-D-Galp-(1->4)-beta-D-GlcpNAc" |
+| `CHEBI:76971` "Escherichia coli metabolite" | 675 | `CHEBI:10048` "XDP", `CHEBI:17044` "D-glucitol 6-phosphate", `CHEBI:27963` "(Kdo)2-lipid A (E. coli)" |
+| `CHEBI:51217` "fluorochrome" | 536 | `CHEBI:132203` "6-carboxyfluorescein succinimidyl ester", `CHEBI:52104` "lucifer yellow dye", `CHEBI:52822` "DY-633(1-)" |
+| `CHEBI:76946` "fungal metabolite" | 471 | `CHEBI:10106` "zearalenone", `CHEBI:184119` "(+)-delta-cadinol", `CHEBI:5325` "gentisyl alcohol" |
+| `CHEBI:33282` "antibacterial agent" | 468 | `CHEBI:10447` "beta-thujaplicin", `CHEBI:29701` "tyrocidine A", `CHEBI:66530` "suaveolindole" |
+| `CHEBI:76967` "human xenobiotic metabolite" | 468 | `CHEBI:10319` "1-naphthol", `CHEBI:138645` "resolvin D5", `CHEBI:45895` "tert-butanol" |
+| `CHEBI:68495` "apoptosis inducer" | 455 | `CHEBI:10037` "wedelolactone", `CHEBI:195198` "calmidazolium chloride", `CHEBI:67988` "ginsenoside Rd" |
+| `CHEBI:67079` "anti-inflammatory agent" | 449 | `CHEBI:10002` "visnagin", `CHEBI:27673` "herbacetin", `CHEBI:6857` "methyl cinnamate" |
+| `CHEBI:22586` "antioxidant" | 354 | `CHEBI:10127` "zonisamide", `CHEBI:27409` "manniflavanone", `CHEBI:66205` "ternstroside C" |
+| `CHEBI:35718` "antifungal agent" | 349 | `CHEBI:10038` "wighteone", `CHEBI:31457` "decanal", `CHEBI:66525` "streptoverticillin" |
+| `CHEBI:35703` "xenobiotic" | 334 | `CHEBI:100241` "ciprofloxacin", `CHEBI:3561` "cetirizine", `CHEBI:75281` "myclobutanil" |
+| `CHEBI:76507` "marine metabolite" | 328 | `CHEBI:109895` "beta-carboline", `CHEBI:189780` "Pectenotoxin 7", `CHEBI:65667` "crambescidin 826" |
+| `CHEBI:149553` "anticoronaviral agent" | 325 | `CHEBI:101381` "aloxistatin", `CHEBI:149878` "[(2S,4As,10aR)-6-acetyloxy-1,1,4a-trimethyl-7-propan-2-yl-2,3,4,10a-tetrahydrophenanthren-2-yl] acetate", `CHEBI:149986` "2-(2,6-Dibromophenyl)-3-(2-thienylmethyl)thiazolidin-4-one" |
+| `CHEBI:78298` "environmental contaminant" | 324 | `CHEBI:100241` "ciprofloxacin", `CHEBI:38067` "propazine", `CHEBI:76324` "N-nitrosopiperidine" |
+| `CHEBI:33286` "agrochemical" | 316 | `CHEBI:106738` "(S)-famoxadone", `CHEBI:34304` "fenobucarb", `CHEBI:4302` "destosyl pyrazolate" |
+| `CHEBI:76956` "Aspergillus metabolite" | 275 | `CHEBI:10352` "beta-amyrin", `CHEBI:155912` "aculene C", `CHEBI:67533` "prenylterphenyllin" |
+| `CHEBI:24527` "herbicide" | 260 | `CHEBI:131998` "cloransulam", `CHEBI:194505` "broclozone", `CHEBI:63558` "DIBOA" |
+| `CHEBI:84087` "human urinary metabolite" | 254 | `CHEBI:10216` "cedr-8-ene", `CHEBI:156087` "diphenylmethanol", `CHEBI:7563` "N-nicotinoylglycine" |

--- a/docs/sources/CHEBI/roles/role_counts.csv
+++ b/docs/sources/CHEBI/roles/role_counts.csv
@@ -1,0 +1,1378 @@
+role_curie,role_label,chemical_count
+CHEBI:25212,metabolite,4546
+CHEBI:76924,plant metabolite,3127
+CHEBI:35610,antineoplastic agent,1976
+CHEBI:77746,human metabolite,1955
+CHEBI:75771,mouse metabolite,1550
+CHEBI:76969,bacterial metabolite,989
+CHEBI:75772,Saccharomyces cerevisiae metabolite,760
+CHEBI:53000,epitope,686
+CHEBI:76971,Escherichia coli metabolite,675
+CHEBI:51217,fluorochrome,536
+CHEBI:76946,fungal metabolite,471
+CHEBI:33282,antibacterial agent,468
+CHEBI:76967,human xenobiotic metabolite,468
+CHEBI:68495,apoptosis inducer,455
+CHEBI:67079,anti-inflammatory agent,449
+CHEBI:22586,antioxidant,354
+CHEBI:35718,antifungal agent,349
+CHEBI:35703,xenobiotic,334
+CHEBI:76507,marine metabolite,328
+CHEBI:149553,anticoronaviral agent,325
+CHEBI:78298,environmental contaminant,324
+CHEBI:33286,agrochemical,316
+CHEBI:76956,Aspergillus metabolite,275
+CHEBI:24527,herbicide,260
+CHEBI:84087,human urinary metabolite,254
+CHEBI:36047,antibacterial drug,241
+CHEBI:86328,antifungal agrochemical,238
+CHEBI:33281,antimicrobial agent,237
+CHEBI:78804,Caenorhabditis elegans metabolite,236
+CHEBI:176497,geroprotector,219
+CHEBI:50113,androgen,215
+CHEBI:75767,animal metabolite,214
+CHEBI:63726,neuroprotective agent,207
+CHEBI:50266,prodrug,196
+CHEBI:86264,rat metabolite,187
+CHEBI:49103,drug metabolite,182
+CHEBI:50904,allergen,182
+CHEBI:35674,antihypertensive agent,181
+CHEBI:77178,histological dye,179
+CHEBI:35617,flavouring agent,178
+CHEBI:50903,carcinogenic agent,175
+CHEBI:59174,hapten,169
+CHEBI:59132,antigen,164
+CHEBI:35475,non-steroidal anti-inflammatory drug,159
+CHEBI:137684,Papio hamadryas metabolite,158
+CHEBI:38068,antimalarial,158
+CHEBI:27311,volatile oil component,157
+CHEBI:35620,vasodilator agent,156
+CHEBI:48578,radical scavenger,151
+CHEBI:78675,fundamental metabolite,149
+CHEBI:38462,EC 3.1.1.7 (acetylcholinesterase) inhibitor,141
+CHEBI:84735,algal metabolite,141
+CHEBI:76964,Penicillium metabolite,137
+CHEBI:76976,bacterial xenobiotic metabolite,137
+CHEBI:131604,Mycoplasma genitalium metabolite,129
+CHEBI:22587,antiviral agent,127
+CHEBI:85234,human blood serum metabolite,125
+CHEBI:35469,antidepressant,121
+CHEBI:35481,non-narcotic analgesic,119
+CHEBI:35526,hypoglycemic agent,117
+CHEBI:35623,anticonvulsant,114
+CHEBI:24852,insecticide,113
+CHEBI:23357,cofactor,111
+CHEBI:50427,platelet aggregation inhibitor,107
+CHEBI:75050,chromogenic compound,106
+CHEBI:48279,serotonergic antagonist,105
+CHEBI:83399,marine xenobiotic metabolite,105
+CHEBI:25435,mutagen,101
+CHEBI:48318,fragrance,101
+CHEBI:48422,angiogenesis inhibitor,100
+CHEBI:48876,muscarinic antagonist,96
+CHEBI:76206,xenobiotic metabolite,96
+CHEBI:76960,Chaetomium metabolite,92
+CHEBI:35482,opioid analgesic,91
+CHEBI:36044,antiviral drug,90
+CHEBI:22153,acaricide,89
+CHEBI:50910,neurotoxin,86
+CHEBI:88188,drug allergen,86
+CHEBI:35705,immunosuppressive agent,83
+CHEBI:50629,cyclooxygenase 2 inhibitor,83
+CHEBI:37733,EC 3.1.1.8 (cholinesterase) inhibitor,77
+CHEBI:35717,sedative,76
+CHEBI:37955,H1-receptor antagonist,75
+CHEBI:38070,anti-arrhythmia drug,75
+CHEBI:75768,mammalian metabolite,75
+CHEBI:50857,anti-allergic agent,74
+CHEBI:26013,pheromone,71
+CHEBI:35474,anxiolytic drug,71
+CHEBI:35472,anti-inflammatory drug,70
+CHEBI:35941,serotonergic agonist,70
+CHEBI:50733,nutraceutical,70
+CHEBI:62868,hepatoprotective agent,68
+CHEBI:61908,EC 1.14.13.39 (nitric oxide synthase) inhibitor,67
+CHEBI:228364,NMR chemical shift reference compound,66
+CHEBI:35221,antimetabolite,64
+CHEBI:55322,mu-opioid receptor agonist,64
+CHEBI:76498,coral metabolite,64
+CHEBI:25442,mycotoxin,63
+CHEBI:35523,bronchodilator agent,63
+CHEBI:48561,dopaminergic antagonist,63
+CHEBI:50919,antiemetic,63
+CHEBI:77307,cardioprotective agent,63
+CHEBI:50249,anticoagulant,62
+CHEBI:50925,EC 2.7.11.1 (non-specific serine/threonine protein kinase) inhibitor,62
+CHEBI:22333,alkylating agent,61
+CHEBI:62434,EC 2.7.10.1 (receptor protein-tyrosine kinase) inhibitor,61
+CHEBI:35493,antipyretic,60
+CHEBI:83056,Daphnia magna metabolite,60
+CHEBI:37958,dye,59
+CHEBI:51371,muscle relaxant,59
+CHEBI:59163,biomarker,59
+CHEBI:38215,calcium channel blocker,58
+CHEBI:64946,anti-HIV agent,58
+CHEBI:35480,analgesic,57
+CHEBI:48001,protein synthesis inhibitor,54
+CHEBI:50646,bone density conservation agent,53
+CHEBI:50908,hepatotoxic agent,53
+CHEBI:61115,EC 3.5.1.98 (histone deacetylase) inhibitor,53
+CHEBI:38161,chelator,52
+CHEBI:140602,Arabidopsis thaliana metabolite,51
+CHEBI:24127,fungicide,51
+CHEBI:68494,apoptosis inhibitor,51
+CHEBI:38637,tyrosine kinase inhibitor,50
+CHEBI:48407,antiparkinson drug,50
+CHEBI:73240,NF-kappaB inhibitor,50
+CHEBI:36333,local anaesthetic,49
+CHEBI:77884,EC 1.14.13.70 (sterol 14alpha-demethylase) inhibitor,49
+CHEBI:35544,EC 1.14.99.1 (prostaglandin-endoperoxide synthase) inhibitor,48
+CHEBI:83075,Daphnia pulex metabolite,48
+CHEBI:33231,antitubercular agent,47
+CHEBI:35530,beta-adrenergic antagonist,47
+CHEBI:48218,antiseptic drug,47
+CHEBI:50630,cyclooxygenase 1 inhibitor,47
+CHEBI:50846,immunomodulator,47
+CHEBI:50905,teratogenic agent,47
+CHEBI:60643,NMDA receptor antagonist,47
+CHEBI:27026,toxin,46
+CHEBI:138880,autophagy inducer,45
+CHEBI:37890,alpha-adrenergic antagonist,45
+CHEBI:49167,anti-asthmatic drug,45
+CHEBI:50514,vasoconstrictor agent,45
+CHEBI:53756,HIV-1 reverse transcriptase inhibitor,45
+CHEBI:26130,biological pigment,44
+CHEBI:26672,siderophore,44
+CHEBI:36335,trypanocidal drug,44
+CHEBI:50949,serotonin uptake inhibitor,44
+CHEBI:67239,EC 3.2.1.20 (alpha-glucosidase) inhibitor,44
+CHEBI:83074,kairomone,44
+CHEBI:35522,beta-adrenergic agonist,43
+CHEBI:35524,sympathomimetic agent,43
+CHEBI:64915,antiplasmodial drug,43
+CHEBI:70868,antileishmanial agent,43
+CHEBI:79091,EC 2.7.11.24 (mitogen-activated protein kinase) inhibitor,43
+CHEBI:25491,nematicide,42
+CHEBI:49201,anti-ulcer drug,42
+CHEBI:59517,DNA synthesis inhibitor,42
+CHEBI:27027,micronutrient,41
+CHEBI:50750,EC 5.99.1.3 [DNA topoisomerase (ATP-hydrolysing)] inhibitor,41
+CHEBI:82665,EC 2.7.11.22 (cyclin-dependent kinase) inhibitor,41
+CHEBI:35457,EC 3.4.15.1 (peptidyl-dipeptidase A) inhibitor,40
+CHEBI:53784,antispasmodic drug,40
+CHEBI:64947,anti-HIV-1 agent,40
+CHEBI:35441,antiinfective agent,39
+CHEBI:33287,fertilizer,38
+CHEBI:76617,EC 2.7.10.2 (non-specific protein-tyrosine kinase) inhibitor,38
+CHEBI:140165,Brassica napus metabolite,37
+CHEBI:33295,diagnostic agent,37
+CHEBI:35820,antiprotozoal drug,37
+CHEBI:38231,phytotoxin,37
+CHEBI:39116,pyrethroid ester insecticide,37
+CHEBI:51065,dopamine agonist,37
+CHEBI:50114,estrogen,36
+CHEBI:50183,P450 inhibitor,36
+CHEBI:51177,antitussive,36
+CHEBI:173084,ferroptosis inhibitor,35
+CHEBI:22583,antifeedant,35
+CHEBI:35222,inhibitor,35
+CHEBI:35679,antilipemic drug,35
+CHEBI:50902,genotoxin,35
+CHEBI:26841,synthetic auxin,34
+CHEBI:173085,ferroptosis inducer,33
+CHEBI:47868,photosensitizing agent,33
+CHEBI:33893,reagent,32
+CHEBI:35195,surfactant,32
+CHEBI:39442,fluorescent probe,32
+CHEBI:73192,EC 1.3.3.4 (protoporphyrinogen oxidase) inhibitor,32
+CHEBI:86327,antifungal drug,32
+CHEBI:136646,proherbicide,31
+CHEBI:22180,EC 2.2.1.6 (acetolactate synthase) inhibitor,31
+CHEBI:50276,EC 5.99.1.2 (DNA topoisomerase) inhibitor,31
+CHEBI:50509,potassium channel blocker,31
+CHEBI:50914,EC 2.7.1.137 (phosphatidylinositol 3-kinase) inhibitor,31
+CHEBI:51039,dopamine uptake inhibitor,31
+CHEBI:60575,phenoxy herbicide,31
+CHEBI:63248,oxidising agent,31
+CHEBI:74518,anti-obesity agent,31
+CHEBI:77182,food colouring,31
+CHEBI:23354,coenzyme,30
+CHEBI:35498,diuretic,30
+CHEBI:35640,adrenergic uptake inhibitor,30
+CHEBI:59683,antipruritic drug,30
+CHEBI:59997,EC 1.14.18.1 (tyrosinase) inhibitor,30
+CHEBI:76779,EC 3.4.21.26 (prolyl oligopeptidase) inhibitor,30
+CHEBI:143231,carbohydrate allergen,29
+CHEBI:35569,alpha-adrenergic agonist,29
+CHEBI:38147,cardiotonic drug,29
+CHEBI:38623,EC 1.4.3.4 (monoamine oxidase) inhibitor,29
+CHEBI:39456,antiglaucoma drug,29
+CHEBI:70722,EC 6.4.1.2 (acetyl-CoA carboxylase) inhibitor,29
+CHEBI:35842,antirheumatic drug,28
+CHEBI:48219,disinfectant,28
+CHEBI:52726,proteasome inhibitor,28
+CHEBI:64912,antimycobacterial drug,28
+CHEBI:64933,melanin synthesis inhibitor,28
+CHEBI:77523,Maillard reaction product,28
+CHEBI:77853,persistent organic pollutant,28
+CHEBI:197449,NMR solvent,27
+CHEBI:35337,central nervous system stimulant,27
+CHEBI:35660,HIV protease inhibitor,27
+CHEBI:48873,cholinergic antagonist,27
+CHEBI:50177,dermatologic drug,27
+CHEBI:63490,explosive,27
+CHEBI:63962,Hsp90 inhibitor,27
+CHEBI:67268,HIV-1 integrase inhibitor,27
+CHEBI:132992,radiosensitizing agent,26
+CHEBI:139566,Jacobaea metabolite,26
+CHEBI:24850,insect attractant,26
+CHEBI:35443,anthelminthic drug,26
+CHEBI:35444,antinematodal drug,26
+CHEBI:37956,histamine antagonist,26
+CHEBI:48878,nicotinic antagonist,26
+CHEBI:55324,gastrointestinal drug,26
+CHEBI:61951,microtubule-destabilising agent,26
+CHEBI:64909,poison,26
+CHEBI:78433,refrigerant,26
+CHEBI:138208,carotenoid biosynthesis inhibitor,25
+CHEBI:147285,EC 3.4.22.69 (SARS coronavirus main proteinase) inhibitor,25
+CHEBI:35856,lipoxygenase inhibitor,25
+CHEBI:37338,radioopaque medium,25
+CHEBI:38157,iron chelator,25
+CHEBI:50505,sweetening agent,25
+CHEBI:65207,vascular endothelial growth factor receptor antagonist,25
+CHEBI:83072,EC 1.3.5.1 [succinate dehydrogenase (quinone)] inhibitor,25
+CHEBI:25512,neurotransmitter,24
+CHEBI:35476,antipsychotic agent,24
+CHEBI:35497,androgen antagonist,24
+CHEBI:38461,carbamate insecticide,24
+CHEBI:38499,mitochondrial cytochrome-bc1 complex inhibitor,24
+CHEBI:49110,peripheral nervous system drug,24
+CHEBI:52425,EC 3.2.1.18 (exo-alpha-sialidase) inhibitor,24
+CHEBI:65191,second generation antipsychotic,24
+CHEBI:35219,plant growth retardant,23
+CHEBI:35225,buffer,23
+CHEBI:37887,adrenergic antagonist,23
+CHEBI:38633,sodium channel blocker,23
+CHEBI:50909,nephrotoxic agent,23
+CHEBI:63247,reducing agent,23
+CHEBI:64911,antimitotic,23
+CHEBI:35223,catalyst,22
+CHEBI:35821,anticholesteremic drug,22
+CHEBI:37670,protease inhibitor,22
+CHEBI:37700,EC 2.7.11.13 (protein kinase C) inhibitor,22
+CHEBI:46787,solvent,22
+CHEBI:47958,nicotinic acetylcholine receptor agonist,22
+CHEBI:48355,non-polar solvent,22
+CHEBI:48550,EC 1.1.1.21 (aldehyde reductase) inhibitor,22
+CHEBI:50370,parasympatholytic,22
+CHEBI:50926,angiogenesis modulating agent,22
+CHEBI:59826,progestin,22
+CHEBI:62488,signalling molecule,22
+CHEBI:76968,fungal xenobiotic metabolite,22
+CHEBI:24853,intercalator,21
+CHEBI:26115,phytoalexin,21
+CHEBI:38828,nonionic surfactant,21
+CHEBI:48358,polar aprotic solvent,21
+CHEBI:48887,bile acid metabolite,21
+CHEBI:60218,mimotope,21
+CHEBI:74440,epidermal growth factor receptor antagonist,21
+CHEBI:74783,astringent,21
+CHEBI:76595,nephroprotective agent,21
+CHEBI:76989,phytoestrogen,21
+CHEBI:140399,specialised pro-resolving mediator,20
+CHEBI:26155,plant growth regulator,20
+CHEBI:35608,EC 3.1.3.48 (protein-tyrosine-phosphatase) inhibitor,20
+CHEBI:37930,phenothiazine antipsychotic drug,20
+CHEBI:64049,food acidity regulator,20
+CHEBI:66980,nootropic agent,20
+CHEBI:91092,EC 2.7.11.26 (tau-protein kinase) inhibitor,20
+CHEBI:35488,central nervous system depressant,19
+CHEBI:48356,protic solvent,19
+CHEBI:50267,protective agent,19
+CHEBI:50503,laxative,19
+CHEBI:64133,EC 2.5.1.58 (protein farnesyltransferase) inhibitor,19
+CHEBI:64964,EC 1.13.11.34 (arachidonate 5-lipoxygenase) inhibitor,19
+CHEBI:139492,sensitiser,18
+CHEBI:37699,protein kinase inhibitor,18
+CHEBI:38317,EC 1.13.11.27 (4-hydroxyphenylpyruvate dioxygenase) inhibitor,18
+CHEBI:66987,radiation protective agent,18
+CHEBI:68481,mTOR inhibitor,18
+CHEBI:24621,hormone,17
+CHEBI:27780,detergent,17
+CHEBI:35499,hallucinogen,17
+CHEBI:50683,EC 1.5.1.3 (dihydrofolate reductase) inhibitor,17
+CHEBI:50751,anti-estrogen,17
+CHEBI:53559,topoisomerase IV inhibitor,17
+CHEBI:63510,EC 3.6.3.9 (Na(+)/K(+)-transporting ATPase) inhibitor,17
+CHEBI:64951,anti-HBV agent,17
+CHEBI:64953,anti-HSV-1 agent,17
+CHEBI:65190,first generation antipsychotic,17
+CHEBI:71031,orphan drug,17
+CHEBI:71692,insect repellent,17
+CHEBI:78031,Wnt signalling inhibitor,17
+CHEBI:33289,avicide,16
+CHEBI:35554,cardiovascular drug,16
+CHEBI:38877,intravenous anaesthetic,16
+CHEBI:50218,EC 3.1.4.* (phosphoric diester hydrolase) inhibitor,16
+CHEBI:50566,nitric oxide donor,16
+CHEBI:50748,antipsoriatic,16
+CHEBI:51121,fluorescent dye,16
+CHEBI:62913,EC 2.4.2.30 (NAD(+) ADP-ribosyltransferase) inhibitor,16
+CHEBI:63175,peptidomimetic,16
+CHEBI:73336,vulnerary,16
+CHEBI:83317,sterol biosynthesis inhibitor,16
+CHEBI:24869,ionophore,15
+CHEBI:26348,prosthetic group,15
+CHEBI:33288,rodenticide,15
+CHEBI:35625,EC 3.5.2.6 (beta-lactamase) inhibitor,15
+CHEBI:37153,EC 3.1.3.16 (phosphoprotein phosphatase) inhibitor,15
+CHEBI:49326,synthetic oral contraceptive,15
+CHEBI:50176,keratolytic drug,15
+CHEBI:51087,protecting group,15
+CHEBI:59282,kappa-opioid receptor agonist,15
+CHEBI:59745,chromatographic reagent,15
+CHEBI:61016,angiotensin receptor antagonist,15
+CHEBI:64696,EC 2.3.1.26 (sterol O-acyltransferase) inhibitor,15
+CHEBI:64924,hepatitis C protease inhibitor,15
+CHEBI:78295,food component,15
+CHEBI:88230,autophagy inhibitor,15
+CHEBI:23530,cytokinin,14
+CHEBI:37336,radioactive imaging agent,14
+CHEBI:37416,EC 2.7.7.6 (RNA polymerase) inhibitor,14
+CHEBI:48560,dopaminergic agent,14
+CHEBI:50247,antidote,14
+CHEBI:50469,EC 3.1.1.4 (phospholipase A2) inhibitor,14
+CHEBI:50502,EC 2.5.1.15 (dihydropteroate synthase) inhibitor,14
+CHEBI:50507,appetite depressant,14
+CHEBI:50684,cross-linking reagent,14
+CHEBI:50847,immunological adjuvant,14
+CHEBI:63457,fibroblast growth factor receptor antagonist,14
+CHEBI:65256,antimicrobial food preservative,14
+CHEBI:66991,sympatholytic agent,14
+CHEBI:70782,PPARalpha agonist,14
+CHEBI:79056,plasticiser,14
+CHEBI:79314,flame retardant,14
+CHEBI:15022,electron donor,13
+CHEBI:166831,copper chelator,13
+CHEBI:23018,EC 4.2.1.1 (carbonic anhydrase) inhibitor,13
+CHEBI:24937,jasmonates,13
+CHEBI:35442,antiparasitic agent,13
+CHEBI:35471,psychotropic drug,13
+CHEBI:37335,MRI contrast agent,13
+CHEBI:38325,muscarinic agonist,13
+CHEBI:38999,GABA-gated chloride channel antagonist,13
+CHEBI:50268,GABA modulator,13
+CHEBI:59544,phosphoantigen,13
+CHEBI:62215,allelochemical,13
+CHEBI:63047,food emulsifier,13
+CHEBI:64054,delta-opioid receptor agonist,13
+CHEBI:64943,EC 3.4.21.1 (chymotrypsin) inhibitor,13
+CHEBI:65259,GABA antagonist,13
+CHEBI:70728,actin polymerisation inhibitor,13
+CHEBI:71476,EC 2.3.1.85 (fatty acid synthase) inhibitor,13
+CHEBI:76988,xenoestrogen,13
+CHEBI:77962,food antioxidant,13
+CHEBI:145947,antiatherosclerotic agent,12
+CHEBI:36063,oxytocic,12
+CHEBI:37848,plant hormone,12
+CHEBI:38867,anaesthetic,12
+CHEBI:39259,pyrethroid ester acaricide,12
+CHEBI:50790,EC 1.14.14.14 (aromatase) inhibitor,12
+CHEBI:50912,cardiotoxic agent,12
+CHEBI:51076,antifouling biocide,12
+CHEBI:55323,antidiarrhoeal drug,12
+CHEBI:59897,EC 2.7.7.49 (RNA-directed DNA polymerase) inhibitor,12
+CHEBI:63054,osteogenesis regulator,12
+CHEBI:64926,serine protease inhibitor,12
+CHEBI:65001,EC 3.1.1.3 (triacylglycerol lipase) inhibitor,12
+CHEBI:65232,EC 3.4.21.5 (thrombin) inhibitor,12
+CHEBI:75047,B-Raf inhibitor,12
+CHEBI:136644,proinsecticide,11
+CHEBI:22917,phytogenic insecticide,11
+CHEBI:25355,mitochondrial respiratory-chain inhibitor,11
+CHEBI:25540,neonicotinoid insectide,11
+CHEBI:25605,nucleoside antibiotic,11
+CHEBI:33904,molluscicide,11
+CHEBI:38323,cholinergic drug,11
+CHEBI:38498,mitochondrial NADH:ubiquinone reductase inhibitor,11
+CHEBI:38870,inhalation anaesthetic,11
+CHEBI:39011,Good's buffer substance,11
+CHEBI:49159,leukotriene antagonist,11
+CHEBI:49200,EC 3.6.3.10 (H(+)/K(+)-exchanging ATPase) inhibitor,11
+CHEBI:50407,acid-base indicator,11
+CHEBI:50792,estrogen receptor antagonist,11
+CHEBI:52290,mitogen,11
+CHEBI:60807,anaesthesia adjuvant,11
+CHEBI:63951,estrogen receptor agonist,11
+CHEBI:64152,cysteine protease inhibitor,11
+CHEBI:64345,MALDI matrix material,11
+CHEBI:64996,EC 1.13.11.33 (arachidonate 15-lipoxygenase) inhibitor,11
+CHEBI:71554,PPARgamma agonist,11
+CHEBI:72768,aryl hydrocarbon receptor agonist,11
+CHEBI:76395,EC 2.3.1.48 (histone acetyltransferase) inhibitor,11
+CHEBI:132272,herbicide safener,10
+CHEBI:132717,bleaching agent,10
+CHEBI:140160,Camellia sinensis metabolite,10
+CHEBI:146270,oneirogen,10
+CHEBI:171664,antiamoebic agent,10
+CHEBI:233423,antifibrotic agent,10
+CHEBI:25078,luciferin,10
+CHEBI:25747,oxidized luciferins,10
+CHEBI:25944,pesticide,10
+CHEBI:33937,macronutrient,10
+CHEBI:38849,blood substitute,10
+CHEBI:38941,schistosomicide drug,10
+CHEBI:50185,fatty acid synthesis inhibitor,10
+CHEBI:50241,cholinesterase reactivator,10
+CHEBI:61966,metabotropic glutamate receptor agonist,10
+CHEBI:64018,protein kinase C agonist,10
+CHEBI:64106,protein kinase agonist,10
+CHEBI:64584,uremic toxin,10
+CHEBI:64932,cathepsin B inhibitor,10
+CHEBI:70770,Aurora kinase inhibitor,10
+CHEBI:76797,EC 2.5.1.18 (glutathione transferase) inhibitor,10
+CHEBI:77715,nasal decongestant,10
+OBI:0002743,,10
+CHEBI:131699,EC 2.7.7.7 (DNA-directed DNA polymerase) inhibitor,9
+CHEBI:138015,endocrine disruptor,9
+CHEBI:138103,inorganic acid,9
+CHEBI:140921,Hedgehog signaling pathway inhibitor,9
+CHEBI:144829,tumour antigen,9
+CHEBI:148436,nitrification inhibitor,9
+CHEBI:149552,emetic,9
+CHEBI:23240,chromophore,9
+CHEBI:35470,central nervous system drug,9
+CHEBI:35634,EC 1.17.3.2 (xanthine oxidase) inhibitor,9
+CHEBI:35664,EC 1.1.1.34/EC 1.1.1.88 (hydroxymethylglutaryl-CoA reductase) inhibitor,9
+CHEBI:37961,H2-receptor antagonist,9
+CHEBI:37962,adrenergic agent,9
+CHEBI:50248,hematologic agent,9
+CHEBI:50390,EC 1.6.5.2 [NAD(P)H dehydrogenase (quinone)] inhibitor,9
+CHEBI:50412,two-colour indicator,9
+CHEBI:50664,matrix metalloproteinase inhibitor,9
+CHEBI:50739,estrogen receptor modulator,9
+CHEBI:51373,GABA agonist,9
+CHEBI:60809,adjuvant,9
+CHEBI:63533,gonadotropin releasing hormone agonist,9
+CHEBI:65023,anti-asthmatic agent,9
+CHEBI:67114,ryanodine receptor agonist,9
+CHEBI:70821,cathepsin L (EC 3.4.22.15) inhibitor,9
+CHEBI:72316,virulence factor,9
+CHEBI:73190,antimutagen,9
+CHEBI:73273,sodium-glucose transport protein subtype 2 inhibitor,9
+CHEBI:74925,EC 3.4.23.46 (memapsin 2) inhibitor,9
+CHEBI:76022,soluble guanylate cyclase activator,9
+CHEBI:77034,mucolytic,9
+CHEBI:77194,EC 2.7.1.33 (pantothenate kinase) inhibitor,9
+CHEBI:83038,Daphnia galeata metabolite,9
+CHEBI:88048,cyanotoxin,9
+CHEBI:138977,quorum sensing inhibitor,8
+CHEBI:139361,TRP channel blocker,8
+CHEBI:145047,antispermatogenic agent,8
+CHEBI:145425,EC 2.7.11.21 (polo kinase) inhibitor,8
+CHEBI:156203,topoisomerase II inhibitor,8
+CHEBI:194338,T-type calcium channel blocker,8
+CHEBI:194423,aquaretic,8
+CHEBI:26645,semiochemical,8
+CHEBI:35678,histamine agonist,8
+CHEBI:35816,leprostatic drug,8
+CHEBI:35818,coccidiostat,8
+CHEBI:38503,EC 1.6.5.3 [NADH:ubiquinone reductase (H(+)-translocating)] inhibitor,8
+CHEBI:38634,voltage-gated sodium channel blocker,8
+CHEBI:39276,fumigant,8
+CHEBI:50137,mu-opioid receptor antagonist,8
+CHEBI:50513,mydriatic agent,8
+CHEBI:50627,EC 3.2.1.1 (alpha-amylase) inhibitor,8
+CHEBI:50671,antithyroid drug,8
+CHEBI:50691,abortifacient,8
+CHEBI:55350,neurokinin-1 receptor antagonist,8
+CHEBI:60186,EC 3.6.3.8 (Ca(2+)-transporting ATPase) inhibitor,8
+CHEBI:61950,microtubule-stabilising agent,8
+CHEBI:62803,fuel additive,8
+CHEBI:63562,glucocorticoid receptor agonist,8
+CHEBI:63673,chemokine receptor 5 antagonist,8
+CHEBI:64577,flour treatment agent,8
+CHEBI:64857,cosmetic,8
+CHEBI:65239,"EC 3.2.1.114 (mannosyl-oligosaccharide 1,3-1,6-alpha-mannosidase) inhibitor",8
+CHEBI:66900,prostaglandin receptor agonist,8
+CHEBI:66981,ophthalmology drug,8
+CHEBI:67267,EC 2.5.1.59 (protein geranylgeranyltransferase type I) inhibitor,8
+CHEBI:68563,P2Y12 receptor antagonist,8
+CHEBI:68581,EC 3.4.21.6 (coagulation factor Xa) inhibitor,8
+CHEBI:68612,EC 3.4.14.5 (dipeptidyl-peptidase IV) inhibitor,8
+CHEBI:70774,capsaicin receptor antagonist,8
+CHEBI:72571,pro-angiogenic agent,8
+CHEBI:72575,alarm pheromone,8
+CHEBI:73296,cholecystokinin antagonist,8
+CHEBI:75325,cathartic,8
+CHEBI:75763,eukaryotic metabolite,8
+CHEBI:75835,anti-anaemic agent,8
+CHEBI:76413,greenhouse gas,8
+CHEBI:77974,food packaging gas,8
+CHEBI:78361,lichen metabolite,8
+CHEBI:78444,EC 3.1.1.1 (carboxylesterase) inhibitor,8
+CHEBI:82655,animal growth promotant,8
+CHEBI:86385,EC 5.3.3.5 (cholestenol Delta-isomerase) inhibitor,8
+CHEBI:90199,c-Met tyrosine kinase inhibitor,8
+CHEBI:91016,GABAA receptor agonist,8
+CHEBI:137114,bromodomain-containing protein 4 inhibitor,7
+CHEBI:144981,EC 3.6.5.2 (small monomeric GTPase) inhibitor,7
+CHEBI:170010,EC 2.7.7.48 (RNA-directed RNA polymerase) inhibitor,7
+CHEBI:22676,auxin,7
+CHEBI:24319,EC 6.3.1.2 (glutamate--ammonia ligase) inhibitor,7
+CHEBI:33292,fuel,7
+CHEBI:35210,spin label,7
+CHEBI:35477,antimanic drug,7
+CHEBI:35487,EC 1.2.1.3 [aldehyde dehydrogenase (NAD(+))] inhibitor,7
+CHEBI:35845,gout suppressant,7
+CHEBI:38807,calcium channel agonist,7
+CHEBI:38869,general anaesthetic,7
+CHEBI:39143,Lewis acid,7
+CHEBI:39277,fumigant insecticide,7
+CHEBI:48354,polar solvent,7
+CHEBI:50141,bronchoconstrictor agent,7
+CHEBI:50781,EC 1.3.1.22 [3-oxo-5alpha-steroid 4-dehydrogenase (NADP(+))] inhibitor,7
+CHEBI:50837,estrogen antagonist,7
+CHEBI:50855,antiatherogenic agent,7
+CHEBI:59010,antiseborrheic,7
+CHEBI:59285,EC 1.14.13.132 (squalene monooxygenase) inhibitor,7
+CHEBI:59941,amphiphile,7
+CHEBI:63332,EC 3.1.3.1 (alkaline phosphatase) inhibitor,7
+CHEBI:63958,cellulose synthesis inhibitor,7
+CHEBI:64047,food additive,7
+CHEBI:64697,acyl-CoA:cholesterol acyltransferase 2 inhibitor,7
+CHEBI:65265,antacid,7
+CHEBI:66993,tocolytic agent,7
+CHEBI:70998,G-protein-coupled receptor agonist,7
+CHEBI:71196,glucagon-like peptide-1 receptor agonist,7
+CHEBI:73182,plant activator,7
+CHEBI:73193,gibberellin biosynthesis inhibitor,7
+CHEBI:75252,insulin-like growth factor receptor 1 antagonist,7
+CHEBI:76720,antisense oligonucleotide,7
+CHEBI:77035,expectorant,7
+CHEBI:78017,food propellant,7
+CHEBI:87183,STAT3 inhibitor,7
+CHEBI:90172,c-Jun N-terminal kinase inhibitor,7
+CHEBI:90415,insulin secretagogue,7
+CHEBI:139503,vitamin D receptor agonist,6
+CHEBI:141153,quinone outside inhibitor,6
+CHEBI:156211,MAIT cell agonist,6
+CHEBI:20854,ATP synthase inhibitor,6
+CHEBI:228138,antinociceptive agent,6
+CHEBI:23924,enzyme inhibitor,6
+CHEBI:25728,osmolyte,6
+CHEBI:35232,radiopharmaceutical,6
+CHEBI:35841,uricosuric drug,6
+CHEBI:36413,anabolic agent,6
+CHEBI:38706,pediculicide,6
+CHEBI:38808,calcium channel modulator,6
+CHEBI:48425,topical anaesthetic,6
+CHEBI:48675,antifibrinolytic drug,6
+CHEBI:49023,prostaglandin antagonist,6
+CHEBI:49323,contraceptive drug,6
+CHEBI:50103,excitatory amino acid agonist,6
+CHEBI:50382,EC 2.4.1.80 (ceramide glucosyltransferase) inhibitor,6
+CHEBI:50406,probe,6
+CHEBI:50445,EC 3.5.4.4 (adenosine deaminase) inhibitor,6
+CHEBI:50913,fixative,6
+CHEBI:51451,endothelin receptor antagonist,6
+CHEBI:53746,EC 1.1.1.205 (IMP dehydrogenase) inhibitor,6
+CHEBI:55347,vitamin K antagonist,6
+CHEBI:62872,EC 1.2.3.1 (aldehyde oxidase) inhibitor,6
+CHEBI:63674,EC 2.6.1.19 (4-aminobutyrate--2-oxoglutarate transaminase) inhibitor,6
+CHEBI:63963,metabotropic glutamate receptor antagonist,6
+CHEBI:64571,NMDA receptor agonist,6
+CHEBI:64949,anti-HIV-2 agent,6
+CHEBI:67199,AP-1 antagonist,6
+CHEBI:68844,phosphodiesterase IV inhibitor,6
+CHEBI:73214,EC 3.6.3.14 (H(+)-transporting two-sector ATPase) inhibitor,6
+CHEBI:73333,scabicide,6
+CHEBI:73335,ultraviolet filter,6
+CHEBI:74152,mordant,6
+CHEBI:75324,excipient,6
+CHEBI:77103,EC 1.3.5.2 [dihydroorotate dehydrogenase (quinone)] inhibitor,6
+CHEBI:77255,EC 3.4.24.83 (anthrax lethal factor endopeptidase) inhibitor,6
+CHEBI:77402,EC 1.8.1.12 (trypanothione-disulfide reductase) inhibitor,6
+CHEBI:77748,EC 3.6.3.44 (xenobiotic-transporting ATPase) inhibitor,6
+CHEBI:77941,EC 3.5.1.4 (amidase) inhibitor,6
+CHEBI:77965,food anticaking agent,6
+CHEBI:77971,raising agent,6
+CHEBI:85046,skin lightening agent,6
+CHEBI:90710,receptor modulator,6
+CHEBI:90749,antidote to cyanide poisoning,6
+CHEBI:131492,Wnt signalling activator,5
+CHEBI:131787,dopamine receptor D2 antagonist,5
+CHEBI:133106,chemical hybridisation agent,5
+CHEBI:136645,profungicide,5
+CHEBI:143130,impurity,5
+CHEBI:143252,ceramide allergen,5
+CHEBI:146246,CB2 receptor agonist,5
+CHEBI:229763,exportin 1 inhibitor,5
+CHEBI:24851,insect growth regulator,5
+CHEBI:24942,juvenile hormone mimic,5
+CHEBI:26089,photosystem-II inhibitor,5
+CHEBI:26220,precocenes,5
+CHEBI:27314,water-soluble vitamin (role),5
+CHEBI:33284,nutrient,5
+CHEBI:38809,ryanodine receptor modulator,5
+CHEBI:39316,mite growth regulator,5
+CHEBI:47867,indicator,5
+CHEBI:48278,serotonergic drug,5
+CHEBI:48668,gamma-secretase modulator,5
+CHEBI:50184,ion transport inhibitor,5
+CHEBI:50433,platelet glycoprotein-IIb/IIIa receptor antagonist,5
+CHEBI:50685,antitrichomonal drug,5
+CHEBI:50864,insulin-sensitizing drug,5
+CHEBI:51068,miotic,5
+CHEBI:51372,neuromuscular agent,5
+CHEBI:52214,ligand,5
+CHEBI:59107,EC 3.4.24.* (metalloendopeptidase) inhibitor,5
+CHEBI:60311,thyroid hormone,5
+CHEBI:60816,immunogen,5
+CHEBI:63060,phase-transfer catalyst,5
+CHEBI:64033,EC 3.5.1.99 (fatty acid amide hydrolase) inhibitor,5
+CHEBI:64922,EC 3.4.21.37 (leukocyte elastase) inhibitor,5
+CHEBI:65255,food preservative,5
+CHEBI:67105,insect sterilant,5
+CHEBI:70982,reactive oxygen species generator,5
+CHEBI:71942,"EC 3.1.4.35 (3',5'-cyclic-GMP phosphodiesterase) inhibitor",5
+CHEBI:72294,nerve growth factor stimulator,5
+CHEBI:72771,breast cancer resistance protein inhibitor,5
+CHEBI:73263,cyclooxygenase 3 inhibitor,5
+CHEBI:74136,lachrymator,5
+CHEBI:74213,EC 1.17.4.1 (ribonucleoside-diphosphate reductase) inhibitor,5
+CHEBI:74236,polymerisation monomer,5
+CHEBI:75282,ergosterol biosynthesis inhibitor,5
+CHEBI:75298,histamine releasing agent,5
+CHEBI:77113,EC 2.7.11.10 (IkappaB kinase) inhibitor,5
+CHEBI:77608,loop diuretic,5
+CHEBI:78152,enzyme mimic,5
+CHEBI:78366,EC 2.7.1.1 (hexokinase) inhibitor,5
+CHEBI:78760,EC 2.7.1.91 (sphingosine kinase) inhibitor,5
+CHEBI:79085,potassium channel opener,5
+CHEBI:79088,EC 3.4.24.35 (gelatinase B) inhibitor,5
+CHEBI:83157,EC 6.2.1.3 (long-chain-fatty-acid--CoA ligase) inhibitor,5
+CHEBI:83319,EC 1.3.1.70 (Delta(14)-sterol reductase) inhibitor,5
+CHEBI:83741,phospholipid biosynthesis inhibitor,5
+CHEBI:84036,EC 3.4.24.24 (gelatinase A) inhibitor,5
+CHEBI:85094,EC 2.7.11.11 (cAMP-dependent protein kinase) inhibitor,5
+CHEBI:88227,potassium ionophore,5
+CHEBI:91202,TGFbeta receptor antagonist,5
+CHEBI:130181,calmodulin antagonist,4
+CHEBI:131611,teichoic acid biosynthesis inhibitor,4
+CHEBI:131809,SMO receptor agonist,4
+CHEBI:133022,B-cell lymphoma 2 inhibitor,4
+CHEBI:134182,platelet-activating factor receptor antagonist,4
+CHEBI:136647,proacaricide,4
+CHEBI:137431,antihypotensive agent,4
+CHEBI:139246,peptide probe,4
+CHEBI:139556,EC 4.1.1.17 (ornithine decarboxylase) inhibitor,4
+CHEBI:140190,calcium-dependent antibiotics,4
+CHEBI:140489,tropomyosin-related kinase B receptor agonist,4
+CHEBI:140535,TRPV1 agonist,4
+CHEBI:140922,glioma-associated oncogene inhibitor,4
+CHEBI:142782,TRPV channel modulator,4
+CHEBI:142783,TRP channel modulator,4
+CHEBI:145410,EC 1.1.1.42 (isocitrate dehydrogenase) inhibitor,4
+CHEBI:167704,necroptosis inhibitor,4
+CHEBI:176342,EC 1.11.1.9 (glutathione peroxidase) inhibitor,4
+CHEBI:177023,somatostatin receptor agonist,4
+CHEBI:195525,EC 2.7.12.1 (dual-specificity kinase) inhibitor,4
+CHEBI:22986,calcium ionophore,4
+CHEBI:231761,convulsant,4
+CHEBI:233442,chemosensitiser,4
+CHEBI:23366,compatible osmolytes,4
+CHEBI:23582,defoliant,4
+CHEBI:24020,fat-soluble vitamin (role),4
+CHEBI:26157,plant growth stimulator,4
+CHEBI:35846,renal agent,4
+CHEBI:35942,neurotransmitter agent,4
+CHEBI:38500,EC 1.9.3.1 (cytochrome c oxidase) inhibitor,4
+CHEBI:38956,ectoparasiticide,4
+CHEBI:39208,antibiotic insecticide,4
+CHEBI:39351,pyrethroid ether insecticide,4
+CHEBI:48353,serine proteinase inhibitor,4
+CHEBI:48705,agonist,4
+CHEBI:48706,antagonist,4
+CHEBI:50568,"EC 3.1.4.17 (3',5'-cyclic-nucleotide phosphodiesterase) inhibitor",4
+CHEBI:50635,EC 3.5.1.5 (urease) inhibitor,4
+CHEBI:50779,appetite enhancer,4
+CHEBI:52629,EC 3.1.26.13 (retroviral ribonuclease H) inhibitor,4
+CHEBI:53121,adenosine A2A receptor antagonist,4
+CHEBI:59283,delta-opioid receptor antagonist,4
+CHEBI:59321,EC 4.1.1.28 (aromatic-L-amino-acid decarboxylase) inhibitor,4
+CHEBI:59647,EC 2.3.1.50 (serine C-palmitoyltransferase) inhibitor,4
+CHEBI:59680,vasopressin receptor antagonist,4
+CHEBI:59727,vasopressin receptor agonist,4
+CHEBI:59740,nucleophilic reagent,4
+CHEBI:60280,EC 3.5.1.2 (glutaminase) inhibitor,4
+CHEBI:63064,crystallisation adjutant,4
+CHEBI:63090,EC 2.4.2.1 (purine-nucleoside phosphorylase) inhibitor,4
+CHEBI:63114,sphingosine-1-phosphate receptor agonist,4
+CHEBI:63720,EC 2.1.1.45 (thymidylate synthase) inhibitor,4
+CHEBI:63932,EC 1.14.16.2 (tyrosine 3-monooxygenase) inhibitor,4
+CHEBI:63957,adenosine A1 receptor antagonist,4
+CHEBI:64154,H3-receptor agonist,4
+CHEBI:64155,H4-receptor agonist,4
+CHEBI:64176,H3-receptor antagonist,4
+CHEBI:64995,EC 1.13.11.31 (arachidonate 12-lipoxygenase) inhibitor,4
+CHEBI:66902,CFTR potentiator,4
+CHEBI:66908,SMO receptor antagonist,4
+CHEBI:67126,colorimetric reagent,4
+CHEBI:68543,pyrimidine synthesis inhibitor,4
+CHEBI:68557,bradykinin receptor antagonist,4
+CHEBI:68640,EC 1.14.99.9 (steroid 17alpha-monooxygenase) inhibitor,4
+CHEBI:70709,progesterone receptor agonist,4
+CHEBI:70822,EC 3.4.22.2 (papain) inhibitor,4
+CHEBI:71181,Sir2 inhibitor,4
+CHEBI:71212,prohormone,4
+CHEBI:72716,EC 2.3.2.13 (protein-glutamine gamma-glutamyltransferase) inhibitor,4
+CHEBI:73196,EC 4.4.1.11 (methionine gamma-lyase) inhibitor,4
+CHEBI:73267,oxidative phosphorylation inhibitor,4
+CHEBI:73416,CB1 receptor antagonist,4
+CHEBI:74529,antidote to paracetamol poisoning,4
+CHEBI:74530,antidote to curare poisoning,4
+CHEBI:76878,EC 2.3.1.* (acyltransferase transferring other than amino-acyl group) inhibitor,4
+CHEBI:77484,EC 1.1.1.25 (shikimate dehydrogenase) inhibitor,4
+CHEBI:77496,bradykinin receptor B2 agonist,4
+CHEBI:77703,EC 4.3.1.3 (histidine ammonia-lyase) inhibitor,4
+CHEBI:77969,food humectant,4
+CHEBI:77970,food thickening agent,4
+CHEBI:78505,venom,4
+CHEBI:78728,EC 1.3.1.72 (Delta(24)-sterol reductase) inhibitor,4
+CHEBI:78763,EC 2.7.11.18 (myosin-light-chain kinase) inhibitor,4
+CHEBI:82824,calpain inhibitor,4
+CHEBI:82933,gut flora metabolite,4
+CHEBI:83146,Daphnia tenebrosa metabolite,4
+CHEBI:85384,GABA reuptake inhibitor,4
+CHEBI:85540,thromboxane A2 antagonist,4
+CHEBI:88285,EC 2.7.12.* [dual-specificity kinases (those acting on Ser/Thr and Tyr residues)] inhibitor,4
+CHEBI:88286,EC 2.7.12.2 (mitogen-activated protein kinase kinase) inhibitor,4
+CHEBI:88295,G-protein-coupled receptor antagonist,4
+CHEBI:90374,histone acetyltransferase activator,4
+CHEBI:90713,retinoic acid receptor alpha antagonist,4
+CHEBI:90755,antidote to opioid poisoning,4
+CHEBI:102248,EC 1.14.11.29 (hypoxia-inducible factor-proline dioxygenase) inhibitor,3
+CHEBI:131509,EC 1.14.99.66 (lysine-specific histone demethylase 1A) inhibitor,3
+CHEBI:131770,EC 3.6.3.49 (channel-conductance-controlling ATPase) inhibitor,3
+CHEBI:132365,EC 1.14.11.2 (procollagen-proline dioxygenase) inhibitor,3
+CHEBI:132772,EC 3.6.5.5 (dynamin GTPase) inhibitor,3
+CHEBI:136860,antidote to sarin poisoning,3
+CHEBI:137514,TRPA1 channel agonist,3
+CHEBI:137626,EC 1.1.1.146 (11beta-hydroxysteroid dehydrogenase) inhibitor,3
+CHEBI:138931,glutamine antagonist,3
+CHEBI:141301,pronematicide,3
+CHEBI:142581,EC 4.1.1.15 (glutamate decarboxylase) inhibitor,3
+CHEBI:142790,EC 3.3.2.10 (soluble epoxide hydrolase) inhibitor,3
+CHEBI:144998,sphingosine-1-phosphate receptor 1 antagonist,3
+CHEBI:145437,uncoupling protein inhibitor,3
+CHEBI:145438,C-X-C chemokine receptor type 4 antagonist,3
+CHEBI:145982,5-hydroxytryptamine 2A receptor agonist,3
+CHEBI:167183,piscicide,3
+CHEBI:167694,EC 2.1.1.43 (enhancer of zeste homolog 2) inhibitor,3
+CHEBI:172949,antimicrobial cosmetic preservative,3
+CHEBI:196956,calcitonin gene-related peptide receptor antagonist,3
+CHEBI:229655,complement factor B inhibitor,3
+CHEBI:23888,drug,3
+CHEBI:36710,interferon inducer,3
+CHEBI:37337,ultrasound contrast agent,3
+CHEBI:38456,ecdysone agonist,3
+CHEBI:48360,amphiprotic solvent,3
+CHEBI:48676,fibrin modulating drug,3
+CHEBI:49020,hormone antagonist,3
+CHEBI:49205,CETP inhibitor,3
+CHEBI:50423,EC 1.6.3.1. [NAD(P)H oxidase (H2O2-forming)] inhibitor,3
+CHEBI:50510,potassium channel modulator,3
+CHEBI:50741,retinoic acid receptor alpha/beta agonist,3
+CHEBI:50844,aldosterone antagonist,3
+CHEBI:51060,hormone agonist,3
+CHEBI:51374,GABA agent,3
+CHEBI:51452,endothelin A receptor antagonist,3
+CHEBI:59672,EC 2.4.1.16 (chitin synthase) inhibitor,3
+CHEBI:59739,electrophilic reagent,3
+CHEBI:59844,antihyperplasia drug,3
+CHEBI:60606,opioid receptor agonist,3
+CHEBI:60798,excitatory amino acid antagonist,3
+CHEBI:60901,EC 2.5.1.9 (riboflavin synthase) inhibitor,3
+CHEBI:62754,glycine receptor antagonist,3
+CHEBI:63721,EC 2.1.2.2 (phosphoribosylglycinamide formyltransferase) inhibitor,3
+CHEBI:63794,retinoid X receptor agonist,3
+CHEBI:64370,glutamate transporter activator,3
+CHEBI:64477,monolignol,3
+CHEBI:64670,EC 1.8.1.9 (thioredoxin reductase) inhibitor,3
+CHEBI:64763,EC 3.1.4.11 (phosphoinositide phospholipase C) inhibitor,3
+CHEBI:64919,EC 2.3.1.20 (diacylglycerol O-acyltransferase) inhibitor,3
+CHEBI:65057,adenosine A1 receptor agonist,3
+CHEBI:66956,antidyskinesia agent,3
+CHEBI:67072,cannabinoid receptor agonist,3
+CHEBI:67200,provitamin A,3
+CHEBI:67231,EC 3.2.1.48 (sucrose alpha-glucosidase) inhibitor,3
+CHEBI:67232,"EC 3.2.1.10 (oligo-1,6-glucosidase) inhibitor",3
+CHEBI:70727,topoisomerase inhibitor,3
+CHEBI:71014,AMPA receptor antagonist,3
+CHEBI:71232,adenosine receptor antagonist,3
+CHEBI:71338,autoinducer,3
+CHEBI:747329,lubricant,3
+CHEBI:74886,neoglycolipid probe,3
+CHEBI:75174,EC 2.5.1.21 (squalene synthase) inhibitor,3
+CHEBI:75358,curing agent,3
+CHEBI:75380,EC 1.11.1.6 (catalase) inhibitor,3
+CHEBI:76787,EC 3.4.11.* (aminopeptidase) inhibitor,3
+CHEBI:76795,EC 3.4.22.36 (caspase-1) inhibitor,3
+CHEBI:76812,EC 2.7.11.* (protein-serine/threonine kinase) inhibitor,3
+CHEBI:76877,EC 2.3.2.* (aminoacyltransferase) inhibitor,3
+CHEBI:76940,EC 3.4.21.4 (trypsin) inhibitor,3
+CHEBI:76977,corticotropin-releasing factor receptor antagonist,3
+CHEBI:77090,EC 4.3.1.10 (serine-sulfate ammonia-lyase) inhibitor,3
+CHEBI:77111,EC 2.1.1.116 [3'-hydroxy-N-methyl-(S)-coclaurine 4'-O-methyltransferase] inhibitor,3
+CHEBI:77318,pregnane X receptor agonist,3
+CHEBI:77567,eugeroic,3
+CHEBI:77705,EC 3.4.19.* (omega-peptidase) inhibitor,3
+CHEBI:77706,EC 3.4.19.3 (pyroglutamyl-peptidase I) inhibitor,3
+CHEBI:77881,EC 4.3.1.15 (diaminopropionate ammonia-lyase) inhibitor,3
+CHEBI:77953,EC 6.1.1.4 (leucine--tRNA ligase) inhibitor,3
+CHEBI:77966,food stabiliser,3
+CHEBI:78006,food colour retention agent,3
+CHEBI:78016,food gelling agent,3
+CHEBI:78024,EC 4.1.1.50 (adenosylmethionine decarboxylase) inhibitor,3
+CHEBI:78248,vitamin B1 antagonist,3
+CHEBI:78379,EC 2.5.1.7 (UDP-N-acetylglucosamine 1-carboxyvinyltransferase) inhibitor,3
+CHEBI:78548,adenylate cyclase agonist,3
+CHEBI:78623,bone morphogenetic protein receptor antagonist,3
+CHEBI:78678,EC 4.6.1.2 (guanylate cyclase) inhibitor,3
+CHEBI:78947,archaeal metabolite,3
+CHEBI:79050,EC 3.4.22.52 (calpain-1) inhibitor,3
+CHEBI:79093,EC 1.11.2.2 (myeloperoxidase) inhibitor,3
+CHEBI:83313,protease-activated receptor-1 antagonist,3
+CHEBI:83762,"EC 3.2.1.28 (alpha,alpha-trehalase) inhibitor",3
+CHEBI:85180,nonnucleoside hepatitis C virus polymerase inhibitor,3
+CHEBI:85185,hepatitis C virus nonstructural protein 5A inhibitor,3
+CHEBI:86029,liver X receptor agonist,3
+CHEBI:86430,EC 1.14.13.78 (ent-kaurene oxidase) inhibitor,3
+CHEBI:90190,EC 2.1.1.37 [DNA (cytosine-5-)-methyltransferase] inhibitor,3
+CHEBI:90285,EC 4.1.1.23 (orotidine-5'-phosphate decarboxylase) inhibitor,3
+CHEBI:90753,antidote to organophosphate poisoning,3
+CHEBI:101086,EC 5.4.99.7 (lanosterol synthase) inhibitor,2
+CHEBI:131186,IP3 receptor antagonist,2
+CHEBI:131794,EC 2.7.11.17 (Ca(2+)/calmodulin-dependent protein kinase) inhibitor,2
+CHEBI:131795,dopamine receptor D1 agonist,2
+CHEBI:132972,farnesoid X receptor agonist,2
+CHEBI:133016,5-hydroxytryptamine 2A receptor inverse agonist,2
+CHEBI:133878,neuropeptide Y receptor antagonist,2
+CHEBI:134084,EC 1.15.1.1 (superoxide dismutase) inhibitor,2
+CHEBI:137079,eukaryotic initiation factor 4F inhibitor,2
+CHEBI:137123,EC 2.7.11.30 (receptor protein serine/threonine kinase) inhibitor,2
+CHEBI:137566,EC 2.5.1.48 (cystathionine gamma-synthase) inhibitor,2
+CHEBI:138416,angiotensin receptor agonist,2
+CHEBI:138956,EC 6.3.5.4 [asparagine synthase (glutamine-hydrolysing)] inhibitor,2
+CHEBI:139084,cis-Golgi ArfGEF GBF inhibitor,2
+CHEBI:139155,melanin-concentrating hormone receptor antagonist,2
+CHEBI:139339,EC 1.14.17.1 (dopamine beta-monooxygenase) inhibitor,2
+CHEBI:139512,EC 1.3.1.9 [enoyl-[acyl-carrier-protein] reductase (NADH)] inhibitor,2
+CHEBI:140061,TRPV4 agonist,2
+CHEBI:140482,neurokinin-3 receptor antagonist,2
+CHEBI:140982,neuropeptide FF receptor antagonist,2
+CHEBI:142184,5-hydroxytryptamine 2B receptor agonist,2
+CHEBI:142185,5-hydroxytryptamine 2C receptor agonist,2
+CHEBI:142738,tau aggregation inhibitor,2
+CHEBI:142781,EC 2.5.1.117 (homogentisate solanesyltransferase) inhibitor,2
+CHEBI:143909,EC 2.7.1.40 (pyruvate kinase) inhibitor,2
+CHEBI:144895,C5a receptor antagonist,2
+CHEBI:144997,sphingosine-1-phosphate receptor 3 antagonist,2
+CHEBI:145253,hyaluronan synthesis inhibitor,2
+CHEBI:145515,GABAA receptor antagonist,2
+CHEBI:145814,EC 1.2.1.11 (aspartate-semialdehyde dehydrogenase) inhibitor,2
+CHEBI:147289,EC 3.4.17.23 (angiotensin-converting enzyme 2) inhibitor,2
+CHEBI:149497,spin trapping reagent,2
+CHEBI:149598,EC 2.3.3.8 (ATP citrate synthase) inhibitor,2
+CHEBI:156297,EC 3.4.21.75 (furin) inhibitor,2
+CHEBI:167633,CPSF3 inhibitor,2
+CHEBI:173100,voltage-dependent anion channel inhibitor,2
+CHEBI:17654,electron acceptor,2
+CHEBI:176961,EC 2.7.11.2 - [pyruvate dehydrogenase (acetyl-transferring)] kinase inhibitor,2
+CHEBI:184301,EC 3.2.1.52 (beta-N-acetylhexosaminidase) inhibitor,2
+CHEBI:188147,urea herbicide,2
+CHEBI:190286,ceramide mimetic,2
+CHEBI:191196,EC 3.2.1.24 (alpha-mannosidase) inhibitor,2
+CHEBI:192269,CB1 receptor agonist,2
+CHEBI:194181,mitochondrial calcium uniporter inhibitor,2
+CHEBI:194467,NOD1 agonist,2
+CHEBI:197347,Rac1 inhibitor,2
+CHEBI:228263,EC 2.1.1.354 ([histone H3]-lysine(4) N-trimethyltransferase) inhibitor,2
+CHEBI:228347,trace amine-associated receptor 1 agonist,2
+CHEBI:229651,"EC 2.7.1.153 (phosphatidylinositol-4,5-bisphosphate 3-kinase) inhibitor",2
+CHEBI:229668,complement component 5 inhibitor,2
+CHEBI:231729,BET bromodomain inhibitor,2
+CHEBI:231911,renoprotective agent,2
+CHEBI:232436,calcium chelator,2
+CHEBI:233404,EC 1.14.11.68 ([histone H3]-trimethyl-L-lysine(27) demethylase) inhibitor,2
+CHEBI:26087,photosynthetic electron-transport chain inhibitor,2
+CHEBI:26088,photosystem-I inhibitor,2
+CHEBI:35204,tracer,2
+CHEBI:35206,isotopic tracer,2
+CHEBI:35207,radioactive tracer,2
+CHEBI:35224,effector,2
+CHEBI:35473,tranquilizing drug,2
+CHEBI:36043,antimicrobial drug,2
+CHEBI:36051,antisyphilitic drug,2
+CHEBI:37886,adrenergic agonist,2
+CHEBI:38155,phytosiderophore,2
+CHEBI:39000,sodium channel modulator,2
+CHEBI:39141,Bronsted acid,2
+CHEBI:39144,Lewis base,2
+CHEBI:39412,bridged diphenyl acaricide,2
+CHEBI:48406,EC 2.1.1.6 (catechol O-methyltransferase) inhibitor,2
+CHEBI:48525,calcimimetic,2
+CHEBI:48539,alpha-adrenergic drug,2
+CHEBI:49324,female contraceptive drug,2
+CHEBI:50188,provitamin,2
+CHEBI:50269,EC 1.1.1.1 (alcohol dehydrogenase) inhibitor,2
+CHEBI:50533,protein denaturant,2
+CHEBI:50643,EC 2.5.1.1 (dimethylallyltranstransferase) inhibitor,2
+CHEBI:50696,EC 2.4.1.129 (peptidoglycan glycosyltransferase) inhibitor,2
+CHEBI:51237,Grignard reagent,2
+CHEBI:52303,sterol methyltransferase inhibitor,2
+CHEBI:52943,carboxylic acid protecting group,2
+CHEBI:53337,tissue adhesive,2
+CHEBI:59229,GnRH antagonist,2
+CHEBI:59886,HIV fusion inhibitor,2
+CHEBI:60258,EC 3.4.* (hydrolases acting on peptide bond) inhibitor,2
+CHEBI:60688,EC 4.2.1.20 (tryptophan synthase) inhibitor,2
+CHEBI:60788,affinity label,2
+CHEBI:60832,tubulin modulator,2
+CHEBI:61015,nephrotoxin,2
+CHEBI:61026,bile therapy drug,2
+CHEBI:62873,odorant receptor agonist,2
+CHEBI:62914,axin stabilizer,2
+CHEBI:63157,EC 4.2.1.22 (cystathionine beta-synthase) inhibitor,2
+CHEBI:63158,EC 2.3.1.21 (carnitine O-palmitoyltransferase) inhibitor,2
+CHEBI:63173,T-cell proliferation inhibitor,2
+CHEBI:63923,sclerotherapy agent,2
+CHEBI:64088,incretin mimetic,2
+CHEBI:64105,protein kinase G agonist,2
+CHEBI:64338,K-ATP channel agonist,2
+CHEBI:64406,EC 3.4.22.38 (cathepsin K) inhibitor,2
+CHEBI:64570,EC 2.1.2.1 (glycine hydroxymethyltransferase) inhibitor,2
+CHEBI:64589,glycine receptor agonist,2
+CHEBI:64952,anti-HSV agent,2
+CHEBI:64957,EC 3.4.21.39 (chymase) inhibitor,2
+CHEBI:65053,EC 4.1.1.19 (arginine decarboxylase) inhibitor,2
+CHEBI:66894,erythropeotin receptor agonist,2
+CHEBI:67189,EC 3.4.24.3 (microbial collagenase) inhibitor,2
+CHEBI:67195,gap junctional intercellular communication inhibitor,2
+CHEBI:67198,retinoic acid receptor agonist,2
+CHEBI:67230,EC 3.2.1.45 (glucosylceramidase) inhibitor,2
+CHEBI:68542,EC 1.3.98.1 [dihydroorotate oxidase (fumarate)] inhibitor,2
+CHEBI:70817,EC 1.2.1.12 [glyceraldehyde-3-phosphate dehydrogenase (phosphorylating)] inhibitor,2
+CHEBI:72298,MTP inhibitor,2
+CHEBI:72483,vesicular glutamate transport inhibitor,2
+CHEBI:72854,"EC 1.13.11.52 (indoleamine 2,3-dioxygenase) inhibitor",2
+CHEBI:73136,EC 1.1.1.184 [carbonyl reductase (NADPH)] inhibitor,2
+CHEBI:73181,EC 1.11.1.11 (L-ascorbate peroxidase) inhibitor,2
+CHEBI:73191,abscisic acid receptor agonist,2
+CHEBI:73310,adenosine A2A receptor agonist,2
+CHEBI:73361,methionine aminopeptidase 2 inhibitor,2
+CHEBI:73668,peptide coupling reagent,2
+CHEBI:73730,PPARbeta/delta agonist,2
+CHEBI:73913,antifolate,2
+CHEBI:73966,nitric oxide synthase activator,2
+CHEBI:74234,"EC 1.1.1.153 [sepiapterin reductase (L-erythro-7,8-dihydrobiopterin forming)] inhibitor",2
+CHEBI:74352,quinol oxidation site inhibitor,2
+CHEBI:74914,microarray analysis reagent,2
+CHEBI:75414,platelet-activating factor receptor agonist,2
+CHEBI:75599,EC 6.3.2.2 (glutamate--cysteine ligase) inhibitor,2
+CHEBI:75968,EC 6.3.2.19 (ubiquitin--protein ligase) inhibitor,2
+CHEBI:76811,EC 3.1.4.12 (sphingomyelin phosphodiesterase) inhibitor,2
+CHEBI:76822,EC 3.2.1.31 (beta-glucuronidase) inhibitor,2
+CHEBI:76871,EC 2.1.1.* (methyltransferases) inhibitor,2
+CHEBI:76902,"EC 1.14.11.* (oxidoreductase acting on paired donors, 2-oxoglutarate as one donor, incorporating 1 atom each of oxygen into both donors) inhibitor",2
+CHEBI:76926,EC 3.4.13.19 (membrane dipeptidase) inhibitor,2
+CHEBI:76998,aryl hydrocarbon receptor antagonist,2
+CHEBI:77020,EC 1.10.99.2 [ribosyldihydronicotinamide dehydrogenase (quinone)] inhibitor,2
+CHEBI:77023,EC 2.3.3.1 [citrate (Si)-synthase] inhibitor,2
+CHEBI:77024,EC 3.1.3.41 (4-nitrophenylphosphatase) inhibitor,2
+CHEBI:77108,EC 1.1.1.141 [15-hydroxyprostaglandin dehydrogenase (NAD(+))] inhibitor,2
+CHEBI:77115,EC 2.1.1.122 [(S)-tetrahydroprotoberberine N-methyltransferase] inhibitor,2
+CHEBI:77118,EC 3.5.5.1 (nitrilase) inhibitor,2
+CHEBI:77161,Toll-like receptor 2 agonist,2
+CHEBI:77495,bradykinin receptor agonist,2
+CHEBI:77731,p53 activator,2
+CHEBI:77745,EC 3.4.24.18 (meprin A) inhibitor,2
+CHEBI:77747,EC 3.6.3.1 (phospholipid-translocating ATPase) inhibitor,2
+CHEBI:77781,EC 1.14.13.181 (13-deoxydaunorubicin hydroxylase) inhibitor,2
+CHEBI:78299,environmental food contaminant,2
+CHEBI:78377,EC 1.3.1.8 [acyl-CoA dehydrogenase (NADP(+))] inhibitor,2
+CHEBI:78547,protein kinase A agonist,2
+CHEBI:78592,vesicant,2
+CHEBI:78606,Hsp70 inducer,2
+CHEBI:78681,tropomyosin-related kinase B receptor antagonist,2
+CHEBI:78928,EC 3.6.1.3 (adenosinetriphosphatase) inhibitor,2
+CHEBI:79386,glycerophosphoinositol synthesis inhibitor,2
+CHEBI:79392,EC 6.1.1.2 (tryptophan--tRNA ligase) inhibitor,2
+CHEBI:82632,phytochrome chromophore,2
+CHEBI:82821,EC 3.4.22.53 (calpain-2) inhibitor,2
+CHEBI:82891,glucocorticoid receptor antagonist,2
+CHEBI:83034,EC 4.1.2.27 (sphinganine-1-phosphate aldolase) inhibitor,2
+CHEBI:83039,crustacean metabolite,2
+CHEBI:83612,hepatic steatosis inducing agent,2
+CHEBI:83757,"EC 2.4.1.231 [alpha,alpha-trehalose phosphorylase (configuration-retaining)] inhibitor",2
+CHEBI:83760,"EC 2.4.1.64 (alpha,alpha-trehalose phosphorylase) inhibitor",2
+CHEBI:83799,nonstructural protein 5A inhibitor,2
+CHEBI:85011,EC 2.6.1.16 (glutamine--fructose-6-phosphate transaminase (isomerizing)) inhibitor,2
+CHEBI:85053,EC 2.7.11.31 {[hydroxymethylglutaryl-CoA reductase (NADPH)] kinase} activator,2
+CHEBI:85424,glycine transporter 2 inhibitor,2
+CHEBI:86966,EC 3.4.21.92 (endopeptidase Clp) inhibitor,2
+CHEBI:87588,Smad3 inhibitor,2
+CHEBI:88336,retinoic acid receptor gamma agonist,2
+CHEBI:88355,alpha-secretase activator,2
+CHEBI:90318,EC 6.4.1.1 (pyruvate carboxylase) inhibitor,2
+CHEBI:90365,EC 4.6.1.1 (adenylate cyclase) inhibitor,2
+CHEBI:90375,Sir1 inhibitor,2
+CHEBI:90845,prostacyclin receptor agonist,2
+CHEBI:90878,EC 2.4.2.4 (thymidine phosphorylase) inhibitor,2
+CHEBI:91079,purinergic receptor P2 antagonist,2
+CHEBI:91081,purinergic receptor P2X antagonist,2
+CHEBI:91085,collagen cross-linking inhibitor,2
+CHEBI:91189,VEGF activator,2
+CHEBI:102368,EC 2.6.1.40 [(R)-3-amino-2-methylpropionate--pyruvate transaminase] inhibitor,1
+CHEBI:110725,EC 2.1.1.8 (histamine N-methyltransferase) inhibitor,1
+CHEBI:131359,adenosine A2B receptor agonist,1
+CHEBI:131495,formyl peptide receptor agonist,1
+CHEBI:131561,hyaluronic acid synthesis inhibitor,1
+CHEBI:131734,EC 2.7.11.20 (elongation factor 2 kinase) inhibitor,1
+CHEBI:131789,RUNX1 inhibitor,1
+CHEBI:131790,melatonin receptor antagonist,1
+CHEBI:131791,HIV-1 Tat inhibitor,1
+CHEBI:131844,EC 1.14.11.1 (gamma-butyrobetaine dioxygenase) inhibitor,1
+CHEBI:131961,"EC 1.13.11.11 (tryptophan 2,3-dioxygenase) inhibitor",1
+CHEBI:132518,EC 3.2.1.23 (beta-galactosidase) inhibitor,1
+CHEBI:132608,TRPM4 channel inhibitor,1
+CHEBI:132710,xenoantigen,1
+CHEBI:132771,EC 3.6.5.* (hydrolases acting on GTP; involved in cellular and subcellular movement) inhibitor,1
+CHEBI:133024,lymphocyte function-associated antigen-1 antagonist,1
+CHEBI:133190,fatty acid oxidation inhibitor,1
+CHEBI:133811,EC 2.4.1.17 (glucuronosyltransferase) inhibitor,1
+CHEBI:133891,salt-inducible kinase 2 inhibitor,1
+CHEBI:133895,EC 2.5.1.46 (deoxyhypusine synthase) inhibitor,1
+CHEBI:134083,hypoxia-inducible factor pathway activator,1
+CHEBI:134108,lipopolysaccharide biosynthesis inhibitor,1
+CHEBI:134109,EC 3.5.1.108 (UDP-3-O-acyl-N-acetylglucosamine deacetylase) inhibitor,1
+CHEBI:134173,antidote to barbiturate poisoning,1
+CHEBI:134545,EC 1.8.1.4 (dihydrolipoyl dehydrogenase) inhibitor,1
+CHEBI:136537,EC 2.4.2.8 (hypoxanthine phosphoribosyltransferase) inhibitor,1
+CHEBI:136580,LRH-1 antagonist,1
+CHEBI:136648,prosafener,1
+CHEBI:136651,S100 calcium-binding protein B inhibitor,1
+CHEBI:136859,pro-agent,1
+CHEBI:136984,EC 4.4.1.14 (1-aminocyclopropane-1-carboxylate synthase) inhibitor,1
+CHEBI:137401,capsaicin receptor agonist,1
+CHEBI:137736,anxiogenic,1
+CHEBI:138014,EC 3.4.22.56 (caspase-3) inhibitor,1
+CHEBI:138090,ATPase motor cytoplasmic dynein inhibitor,1
+CHEBI:138168,neuropeptide Y2 receptor agonist,1
+CHEBI:138380,RhoA inhibitor,1
+CHEBI:138381,RhoC inhibitor,1
+CHEBI:138390,EC 1.1.1.159 (7alpha-hydroxysteroid dehydrogenase) inhibitor,1
+CHEBI:138887,prostaglandin receptor antagonist,1
+CHEBI:138921,EC 6.3.5.5 [carbamoyl-phosphate synthase (glutamine-hydrolysing)] inhibitor,1
+CHEBI:138925,EC 6.3.4.2 [CTP synthase (glutamine hydrolyzing)] inhibitor,1
+CHEBI:138927,EC 6.3.5.3 (phosphoribosylformylglycinamidine synthase) inhibitor,1
+CHEBI:138928,EC 6.3.5.2 [GMP synthase (glutamine-hydrolysing)] inhibitor,1
+CHEBI:138938,EC 4.1.1.39 (ribulose-bisphosphate carboxylase) inhibitor,1
+CHEBI:138952,EC 2.4.2.14 (amidophosphoribosyltransferase) inhibitor,1
+CHEBI:138953,EC 6.3.5.1 [NAD(+) synthase (glutamine-hydrolysing)] inhibitor,1
+CHEBI:139044,thromboxane A2 agonist,1
+CHEBI:139055,PERK inhibitor,1
+CHEBI:139074,LIM kinase inhibitor,1
+CHEBI:139109,IP3 receptor agonist,1
+CHEBI:139153,EC 2.4.1.255 (protein O-GlcNAc transferase) inhibitor,1
+CHEBI:139180,nicotinic acid adenine dinucleotide phosphate receptor antagonist,1
+CHEBI:139584,lysophosphatidic acid receptor 3 agonist,1
+CHEBI:139609,survivin suppressant,1
+CHEBI:140378,EC 1.1.1.37 (malate dehydrogenase) inhibitor,1
+CHEBI:140701,secreted frizzled-related protein 1 inhibitor,1
+CHEBI:141000,neuropeptide FF receptor agonist,1
+CHEBI:141001,kisspeptin receptor agonist,1
+CHEBI:142480,EC 1.14.14.94 (leukotriene-B4 20-monooxygenase) inhibitor,1
+CHEBI:142481,EC 1.14.15.3 (alkane 1-monooxygenase) inhibitor,1
+CHEBI:143001,GABAB receptor agonist,1
+CHEBI:143003,EC 2.1.3.3 (ornithine carbamoyltransferase) inhibitor,1
+CHEBI:143204,peptide allergen,1
+CHEBI:143828,EC 1.14.14.154 (sterol 14alpha-demethylase) inhibitor,1
+CHEBI:144064,EC 1.14.15.6 cholesterol monooxygenase (side-chain-cleaving) inhibitor,1
+CHEBI:144097,EC 1.4.3.2 (L-amino-acid oxidase) inhibitor,1
+CHEBI:144099,EC 2.6.1.2 (alanine transaminase) inhibitor,1
+CHEBI:144387,EC 2.7.1.105 (6-phosphofructo-2-kinase) inhibitor,1
+CHEBI:144455,EC 3.1.1.64 (retinoid isomerohydrolase) inhibitor,1
+CHEBI:145807,forkhead box protein O1 inhibitor,1
+CHEBI:146223,ryanodine receptor antagonist,1
+CHEBI:149639,EC 3.4.21.36 (pancreatic elastase) inhibitor,1
+CHEBI:149711,chemokine receptor 2 antagonist,1
+CHEBI:150006,SERCA activator,1
+CHEBI:156527,EC 2.4.1.109 (dolichyl-phosphate-mannose-protein mannosyltransferase) inhibitor,1
+CHEBI:166822,EC 3.4.23.15 (renin) inhibitor,1
+CHEBI:166909,neuropilin receptor antagonist,1
+CHEBI:167165,kappa-opioid receptor antagonist,1
+CHEBI:167523,ovicide,1
+CHEBI:167677,EC 6.1.1.6 (lysine--tRNA ligase) inhibitor,1
+CHEBI:172326,EC 2.1.1.348 (mRNA m6A methyltransferase) inhibitor,1
+CHEBI:172919,EC 2.6.1.11 (acetylornithine transaminase) inhibitor,1
+CHEBI:173094,EC 3.1.3.25 (inositol-phosphate phosphatase) inhibitor,1
+CHEBI:173108,thioredoxin inhibitor,1
+CHEBI:176495,actin polymerisation inducer,1
+CHEBI:176508,ferroptosis suppressor protein 1 inhibitor,1
+CHEBI:183050,neoantigen,1
+CHEBI:184380,EC 1.14.14.91 ( trans-cinnamate 4-monooxygenase) inhibitor,1
+CHEBI:189665,EC 3.4.21.61 (kexin) inhibitor,1
+CHEBI:189675,PAR2 negative allosteric modulator,1
+CHEBI:189684,sigma-2 receptor agonist,1
+CHEBI:192504,elicitor,1
+CHEBI:192999,EC 6.2.1.45 (E1 ubiquitin-activating enzyme) inhibitor,1
+CHEBI:194137,neurokinin-1 receptor agonist,1
+CHEBI:194154,piezo1 agonist,1
+CHEBI:194187,gastric inhibitory polypeptide receptor agonist,1
+CHEBI:194430,antimyopathic agent,1
+CHEBI:195251,activator,1
+CHEBI:195252,enzyme activator,1
+CHEBI:195331,EC 2.6.1.13 (ornithine aminotransferase) inhibitor,1
+CHEBI:195444,insulin-like growth factor-binding protein inhibitor,1
+CHEBI:195530,PCNA inhibitor,1
+CHEBI:195542,sphingosine-1-phosphate receptor 2 antagonist,1
+CHEBI:195561,EC 3.5.3.1 (arginase) inhibitor,1
+CHEBI:20569,EC 2.5.1.19 (3-phosphoshikimate 1-carboxyvinyltransferase) inhibitor,1
+CHEBI:22309,alicyclic antibiotics,1
+CHEBI:22581,antiauxins,1
+CHEBI:228237,sigma-1 receptor agonist,1
+CHEBI:228284,WNK signaling inhibitor,1
+CHEBI:228801,heat shock factor 1 inhibitor,1
+CHEBI:229227,sodium-glucose transport protein subtype 1 inhibitor,1
+CHEBI:229692,IAP antagonist,1
+CHEBI:229783,glucose transporter 1 inhibitor,1
+CHEBI:230471,"EC 2.4.1.34 (1,3-beta-glucan synthase) inhibitor",1
+CHEBI:231708,EC 2.4.2.12 (nicotinamide phosphoribosyltransferase) inhibitor,1
+CHEBI:231732,CXCR2 antagonist,1
+CHEBI:231760,EC 1.3.1.6 (fumarate reductase (NADH)) inhibitor,1
+CHEBI:231916,NLRP3 inhibitor,1
+CHEBI:232442,p53 inhibitor,1
+CHEBI:232530,mass spectrometer degradation product,1
+CHEBI:233336,P2Y14 receptor antagonist,1
+CHEBI:234036,EC 3.2.1.169 (protein O-GlcNAcase) inhibitor,1
+CHEBI:234089,OLIG2 inhibitor,1
+CHEBI:234474,Toll-like receptor 7 agonist,1
+CHEBI:234476,centromere protein E inhibitor,1
+CHEBI:234483,monocarboxylate transporter 1 inhibitor,1
+CHEBI:234572,protein aggregation inhibitor,1
+CHEBI:23529,cytochrome-b6f complex inhibitor,1
+CHEBI:235466,EC 2.4.2.28 (S-methyl-5'-thioadenosine phosphorylase) inhibitor,1
+CHEBI:235515,EC 3.2.1.21 (beta-glucosidase) inhibitor,1
+CHEBI:235516,EC 3.2.1.25 (beta-mannosidase) inhibitor,1
+CHEBI:24002,ethylene releasers,1
+CHEBI:24028,iron(3+) chelator,1
+CHEBI:25573,nodulation factor,1
+CHEBI:25943,pesticide synergist,1
+CHEBI:26413,pyrethroid insecticide,1
+CHEBI:33280,molecular messenger,1
+CHEBI:35208,physical tracer,1
+CHEBI:35211,radioactive label,1
+CHEBI:35226,spin probe,1
+CHEBI:35230,fossil fuel,1
+CHEBI:35684,antiplatyhelmintic drug,1
+CHEBI:36053,acaricide drug,1
+CHEBI:38060,triazine insecticide,1
+CHEBI:38234,DNA polymerase inhibitor,1
+CHEBI:38324,cholinergic agonist,1
+CHEBI:38632,membrane transport modulator,1
+CHEBI:39142,Bronsted base,1
+CHEBI:39216,antibiotic acaricide,1
+CHEBI:39217,antibiotic nematicide,1
+CHEBI:39301,sulfite ester acaricide,1
+CHEBI:39318,tetrazine acaricide,1
+CHEBI:39369,pyrethroid ether acaricide,1
+CHEBI:39378,homopteran inhibitor of chitin biosynthesis,1
+CHEBI:39379,lepidopteran inhibitor of chitin biosynthesis,1
+CHEBI:39415,dinitrophenol insecticide,1
+CHEBI:48357,aprotic solvent,1
+CHEBI:49325,oral contraceptive,1
+CHEBI:50408,visual indicator,1
+CHEBI:50410,colour indicator,1
+CHEBI:50444,adenosine phosphodiesterase inhibitor,1
+CHEBI:50504,osmotic diuretic,1
+CHEBI:50745,progestogen,1
+CHEBI:50788,EC 1.1.1.210 [3beta(or 20alpha)-hydroxysteroid dehydrogenase] inhibitor,1
+CHEBI:50827,antiparathyroid drug,1
+CHEBI:51061,hormone receptor modulator,1
+CHEBI:51577,partial prostacyclin agonist,1
+CHEBI:52206,biochemical role,1
+CHEBI:52217,pharmaceutical,1
+CHEBI:52271,squaraine dye,1
+CHEBI:52424,EC 3.2.1.* (glycosidase) inhibitor,1
+CHEBI:52941,phosphate protecting group,1
+CHEBI:53142,P2Y2 receptor agonist,1
+CHEBI:53353,GHB receptor agonist,1
+CHEBI:53431,chain carrier,1
+CHEBI:53659,EC 1.4.3.22 (diamine oxidase) inhibitor,1
+CHEBI:55351,substance P receptor antagonist,1
+CHEBI:59752,bolaamphiphile,1
+CHEBI:60605,opioid receptor antagonist,1
+CHEBI:60646,chiral reagent,1
+CHEBI:60649,glucagon receptor antagonist,1
+CHEBI:61774,inositol phosphorylceramide synthase inhibitor,1
+CHEBI:62049,acyl donor,1
+CHEBI:62089,EC 1.4.7.1 [glutamate synthase (ferredoxin)] inhibitor,1
+CHEBI:62530,EC 2.3.1.24 (sphingosine N-acyltransferase) inhibitor,1
+CHEBI:62608,EC 4.2.1.3 (aconitate hydratase) inhibitor,1
+CHEBI:62609,EC 3.11.1.3 (phosphonopyruvate hydrolase) inhibitor,1
+CHEBI:62871,EC 4.3.1.24 (phenylalanine ammonia-lyase) inhibitor,1
+CHEBI:62887,tankyrase inhibitor,1
+CHEBI:62915,sialyltransferase inhibitor,1
+CHEBI:63146,insulin release inhibitor,1
+CHEBI:63156,EC 1.1.3.13 (alcohol oxidase) inhibitor,1
+CHEBI:63330,sodium-dependent Pi-transporter inhibitor,1
+CHEBI:63908,film-forming compound,1
+CHEBI:63936,alpha1B-adrenoceptor antagonist,1
+CHEBI:64102,AMPA receptor agonist,1
+CHEBI:64237,EC 2.7.8.15 (UDP-N-acetylglucosamine--dolichyl-phosphate N-acetylglucosaminephosphotransferase) inhibitor,1
+CHEBI:64297,reaction intermediate,1
+CHEBI:64411,EC 2.5.1.29 (geranylgeranyl diphosphate synthase) inhibitor,1
+CHEBI:64416,EC 1.3.1.43 (arogenate dehydrogenase) inhibitor,1
+CHEBI:64588,glycine transporter 1 inhibitor,1
+CHEBI:64920,EC 6.5.1.1 [DNA ligase (ATP)] inhibitor,1
+CHEBI:64954,anti-HSV-2 agent,1
+CHEBI:64955,EC 3.2.1.166 (heparanase) inhibitor,1
+CHEBI:65056,EC 3.1.3.11 (fructose-bisphosphatase) inhibitor,1
+CHEBI:65064,EC 2.1.1.79 (cyclopropane-fatty-acyl-phospholipid synthase) inhibitor,1
+CHEBI:65065,EC 2.1.1.72 [site-specific DNA-methyltransferase (adenine-specific)] inhibitor,1
+CHEBI:65254,LRH-1 agonist,1
+CHEBI:67137,NMR shift reagent,1
+CHEBI:68509,glutathione depleting agent,1
+CHEBI:68553,guanylate cyclase 2C agonist,1
+CHEBI:70724,cell dedifferentiation agent,1
+CHEBI:70725,adenosine A3 receptor antagonist,1
+CHEBI:70781,PPAR modulator,1
+CHEBI:71027,progesterone receptor modulator,1
+CHEBI:71033,carbamylphosphate synthetase I activator,1
+CHEBI:71168,HIV-1 maturation inhibitor,1
+CHEBI:71173,H1-receptor agonist,1
+CHEBI:71178,EC 2.1.1.4 (acetylserotonin O-methyltransferase) inhibitor,1
+CHEBI:71551,EC 3.5.1.23 (ceramidase) inhibitor,1
+CHEBI:71951,EC 3.5.1.88 (peptide deformylase) inhibitor,1
+CHEBI:72311,glucagon-like peptide-2 receptor agonist,1
+CHEBI:72470,provitamin B1,1
+CHEBI:72773,carotogenesis inhibitor,1
+CHEBI:72774,EC 1.3.99.29 [phytoene desaturase (zeta-carotene-forming)] inhibitor,1
+CHEBI:73189,brassinosteroid biosynthesis inhibitor,1
+CHEBI:73311,adenosine receptor agonist,1
+CHEBI:73319,adenosine A3 receptor agonist,1
+CHEBI:73352,protein-sequencing agent,1
+CHEBI:73354,EC 2.7.3.2 (creatine kinase) inhibitor,1
+CHEBI:73417,CB2 receptor antagonist,1
+CHEBI:73618,spectrophotometric reagent,1
+CHEBI:73623,tolerogen,1
+CHEBI:73911,vibriostatic agent,1
+CHEBI:74520,EC 1.1.1.44 (NADP(+)-dependent decarboxylating phosphogluconate dehydrogenase) inhibitor,1
+CHEBI:74570,EC 2.3.2.2 (gamma-glutamyltransferase) inhibitor,1
+CHEBI:747331,plastic stabilizer,1
+CHEBI:747333,plastic filler,1
+CHEBI:747337,plastic adhesive,1
+CHEBI:747338,plastic heat stabilizer,1
+CHEBI:747339,plastic light stabilizer,1
+CHEBI:747341,impact modifier,1
+CHEBI:747342,polymerization initiator,1
+CHEBI:747343,plastic odor agent,1
+CHEBI:74949,EC 3.1.27.3 (ribonuclease T1) inhibitor,1
+CHEBI:75190,"EC 5.4.3.2 (lysine 2,3-aminomutase) inhibitor",1
+CHEBI:75416,EC 6.1.1.* (ligases forming aminoacyl tRNA and related compounds) inhibitor,1
+CHEBI:75429,EC 1.4.4.2 [glycine dehydrogenase (aminomethyl-transferring)] inhibitor,1
+CHEBI:75495,EC 6.1.1.11 (serine--tRNA ligase) inhibitor,1
+CHEBI:76219,fluorogen,1
+CHEBI:76531,odorant receptor antagonist,1
+CHEBI:76648,fluorescence quencher,1
+CHEBI:76693,EC 5.2.* (cis-trans-isomerase) inhibitor,1
+CHEBI:76733,EC 1.6.* (oxidoreductase acting on NADH or NADPH) inhibitor,1
+CHEBI:76773,EC 3.1.1.* (carboxylic ester hydrolase) inhibitor,1
+CHEBI:76798,EC 1.14.15.4 (steroid 11beta-monooxygenase) inhibitor,1
+CHEBI:76828,EC 5.1.1.* (racemases acting on amino acids and derivatives) inhibitor,1
+CHEBI:76841,"EC 1.14.13.* (oxidoreductase acting on paired donors, incorporating 1 atom of oxygen, with NADH or NADPH as one donor) inhibitor",1
+CHEBI:76869,"EC 1.8.1.* (oxidoreductase acting on sulfur group of donors, NAD(+) or NADP(+) as acceptor) inhibitor",1
+CHEBI:76879,EC 2.6.1.* (transaminase) inhibitor,1
+CHEBI:76881,EC 2.7.1.* (phosphotransferases with an alcohol group as acceptor) inhibitor,1
+CHEBI:76885,EC 3.4.23.* (aspartic endopeptidase) inhibitor,1
+CHEBI:76891,EC 3.4.11.14 (cytosol alanyl aminopeptidase) inhibitor,1
+CHEBI:76893,EC 3.4.14.2 (dipeptidyl-peptidase II) inhibitor,1
+CHEBI:76907,EC 4.2.1.* (hydro-lyases) inhibitor,1
+CHEBI:76916,hyperglycemic agent,1
+CHEBI:76938,EC 3.6.4.* (hydrolases acting on ATP; involved in cellular and subcellular movement) inhibitor,1
+CHEBI:76939,EC 3.6.4.10 (non-chaperonin molecular chaperone ATPase) inhibitor,1
+CHEBI:76973,Streptococcus pneumoniae metabolite,1
+CHEBI:76990,mycoestrogen,1
+CHEBI:77089,EC 2.5.1.49 (O-acetylhomoserine aminocarboxypropyltransferase) inhibitor,1
+CHEBI:77106,EC 1.10.2.2 (quinol--cytochrome-c reductase) inhibitor,1
+CHEBI:77110,EC 1.21.3.3 (reticuline oxidase) inhibitor,1
+CHEBI:77119,EC 1.1.1.189 (prostaglandin-E2 9-reductase) inhibitor,1
+CHEBI:77324,UDP-glucuronosyltransferase activator,1
+CHEBI:77326,androstane receptor agonist,1
+CHEBI:77425,EC 1.1.1.188 (prostaglandin-F synthase) inhibitor,1
+CHEBI:77654,EC 1.1.1.267 (1-deoxy-D-xylulose-5-phosphate reductoisomerase) inhibitor,1
+CHEBI:77750,ATP/ADP translocase inhibitor,1
+CHEBI:77758,"EC 3.1.4.53 (3',5'-cyclic-AMP phosphodiesterase) inhibitor",1
+CHEBI:77763,EC 1.2.1.88 (L-glutamate gamma-semialdehyde dehydrogenase) inhibitor,1
+CHEBI:77783,EC 1.14.13.67 (quinine 3-monooxygenase) inhibitor,1
+CHEBI:77960,food firming agent,1
+CHEBI:77963,sequestrant,1
+CHEBI:78003,food bleaching agent,1
+CHEBI:78004,food bulking agent,1
+CHEBI:78009,Wiskott-Aldrich syndrome protein inhibitor,1
+CHEBI:78058,food antifoaming agent,1
+CHEBI:78059,food additive carrier,1
+CHEBI:78372,EC 3.1.1.5 (lysophospholipase) inhibitor,1
+CHEBI:78380,EC 3.5.4.1 (cytosine deaminase) inhibitor,1
+CHEBI:78384,EC 5.1.3.2 (UDP-glucose 4-epimerase) inhibitor,1
+CHEBI:78622,EC 2.7.11.31 {[hydroxymethylglutaryl-CoA reductase (NADPH)] kinase} inhibitor,1
+CHEBI:78691,EC 2.3.1.97 (glycylpeptide N-tetradecanoyltransferase) inhibitor,1
+CHEBI:78756,EC 2.5.1.6 (methionine adenosyltransferase) inhibitor,1
+CHEBI:78803,nematode metabolite,1
+CHEBI:78926,survivin dimerisation modulator,1
+CHEBI:79046,melatonin receptor agonist,1
+CHEBI:82756,EC 6.1.1.12 (aspartate--tRNA ligase) inhibitor,1
+CHEBI:82973,EC 3.4.24.11 (neprilysin) inhibitor,1
+CHEBI:82974,EC 3.4.24.71 (endothelin-converting enzyme 1) inhibitor,1
+CHEBI:83296,orexin receptor antagonist,1
+CHEBI:83316,EC 1.14.13.72 (methylsterol monooxygenase) inhibitor,1
+CHEBI:84012,EC 4.2.1.94 (scytalone dehydratase) inhibitor,1
+CHEBI:84264,EC 3.5.1.19 (nicotinamidase) inhibitor,1
+CHEBI:84297,EC 3.4.21.64 (peptidase K) inhibitor,1
+CHEBI:84799,EC 2.3.1.5 (arylamine N-acetyltransferase) inhibitor,1
+CHEBI:84800,EC 2.4.1.1 (glycogen phosphorylase) inhibitor,1
+CHEBI:84801,EC 2.7.1.127 (inositol-trisphosphate 3-kinase) inhibitor,1
+CHEBI:84802,EC 2.7.1.151 (inositol-polyphosphate multikinase) inhibitor,1
+CHEBI:84804,EC 2.7.4.6 (nucleoside-diphosphate kinase) inhibitor,1
+CHEBI:85012,thrombopoietin receptor agonist,1
+CHEBI:85049,EC 1.10.3.1 (catechol oxidase) inhibitor,1
+CHEBI:85050,EC 1.10.3.2 (laccase) inhibitor,1
+CHEBI:85051,"EC 1.13.11.24 (quercetin 2,3-dioxygenase) inhibitor",1
+CHEBI:85052,EC 1.4.3.3 (D-amino-acid oxidase) inhibitor,1
+CHEBI:85113,EC 2.7.11.12 (cGMP-dependent protein kinase) inhibitor,1
+CHEBI:85618,"EC 2.5.1.31 {ditrans,polycis-undecaprenyl-diphosphate synthase [(2E,6E)-farnesyl-diphosphate specific]} inhibitor",1
+CHEBI:86010,EC 1.4.1.3 {glutamate dehydrogenase [NAD(P)(+)]} inhibitor,1
+CHEBI:86501,EC 1.14.13.97 (taurochenodeoxycholate 6alpha-hydroxylase) inhibitor,1
+CHEBI:87786,signal transducer and activator of transcription 5 protein inhibitor,1
+CHEBI:90113,EC 1.1.1.170 [3beta-hydroxysteroid-4alpha-carboxylate 3-dehydrogenase (decarboxylating)] inhibitor,1
+CHEBI:90691,EC 5.3.1.1 (triose-phosphate isomerase) inhibitor,1
+CHEBI:90709,nuclear receptor modulator,1
+CHEBI:90714,retinoic acid receptor antagonist,1
+CHEBI:90742,retinoic acid receptor beta agonist,1
+CHEBI:90744,retinoic acid receptor gamma antagonist,1
+CHEBI:90757,antidote to benzodiazepine poisoning,1
+CHEBI:90767,eukaryotic translation elongation factor 1alpha 1 inhibitor,1
+CHEBI:90780,AKT1 kinase inhibitor,1
+CHEBI:90846,liver X receptor inverse agonist,1
+CHEBI:90921,EC 1.8.5.4 (sulfide:quinone reductase) inhibitor,1
+CHEBI:90961,ERK dimerisation inhibitor,1
+CHEBI:90991,steroid receptor coactivator stimulator,1
+CHEBI:91015,corrosion inhibitor,1
+CHEBI:91025,erythropoietin inhibitor,1
+CHEBI:91139,elastin-laminin receptor agonist,1
+CHEBI:91141,EC 1.1.5.3 (glycerol-3-phosphate dehydrogenase) inhibitor,1
+CHEBI:91193,lysophosphatidic acid receptor antagonist,1
+CHEBI:91214,macrophage migration inhibitory factor inhibitor,1

--- a/docs/sources/CHEBI/roles/scripts/audit_chebi_roles.py
+++ b/docs/sources/CHEBI/roles/scripts/audit_chebi_roles.py
@@ -1,0 +1,107 @@
+"""Summarise the ChEBI role property file produced by make_chebi_roles().
+
+Writes a Markdown report ranking roles by how many chemicals carry them, and a CSV holding the
+count for every role. See docs/sources/CHEBI/roles/README.md for what the numbers mean.
+
+Imports CHEBI_ROLE_ROOT and HAS_ROLE from the production module rather than restating them, so this
+audit cannot drift from the ingest it is describing.
+
+Usage:
+    uv run python docs/sources/CHEBI/roles/scripts/audit_chebi_roles.py \
+        babel_outputs/intermediate/chemicals/properties/chebi_roles.jsonl.gz \
+        babel_downloads/CHEBI/labels
+"""
+
+import argparse
+import csv
+import gzip
+import json
+from collections import defaultdict
+
+from src.createcompendia.chemicals import CHEBI_ROLE_ROOT
+from src.predicates import HAS_ROLE
+
+# How many roles the Markdown report lists. The full ranking goes to the CSV beside it; the report
+# is an argument a person reads top to bottom, so it gets a sample rather than 1,377 rows.
+REPORT_TOP_N = 25
+
+# How many example chemicals to show per role. Spread across the role's chemicals rather than taken
+# from the front, so the sample is not just "the lowest ChEBI identifiers".
+EXAMPLES_PER_ROLE = 3
+
+
+def read_labels(labels_filename):
+    """Read a Babel labels file (CURIE\\tlabel) into a dict."""
+    labels = {}
+    with open(labels_filename) as f:
+        for line in f:
+            curie, _, label = line.rstrip("\n").partition("\t")
+            labels.setdefault(curie, label)
+    return labels
+
+
+def read_roles(properties_filename):
+    """Read the role property file into {role CURIE: sorted list of chemical CURIEs}."""
+    chemicals_by_role = defaultdict(set)
+    with gzip.open(properties_filename, "rt") as f:
+        for line in f:
+            prop = json.loads(line)
+            if prop["predicate"] != HAS_ROLE:
+                continue
+            chemicals_by_role[prop["value"]].add(prop["curie"])
+    return {role: sorted(chemicals) for role, chemicals in chemicals_by_role.items()}
+
+
+def spread_examples(items, count):
+    """Take `count` items spread evenly across `items`, rather than the first `count`."""
+    if len(items) <= count:
+        return items
+    step = len(items) / count
+    return [items[int(i * step)] for i in range(count)]
+
+
+def describe(curie, labels):
+    label = labels.get(curie)
+    return f'`{curie}` "{label}"' if label else f"`{curie}`"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("properties", help="chebi_roles.jsonl.gz, as written by make_chebi_roles().")
+    parser.add_argument("labels", help="babel_downloads/CHEBI/labels, for role and chemical names.")
+    parser.add_argument("--report", default="docs/sources/CHEBI/roles/role_audit.md")
+    parser.add_argument("--csv", default="docs/sources/CHEBI/roles/role_counts.csv")
+    args = parser.parse_args()
+
+    labels = read_labels(args.labels)
+    chemicals_by_role = read_roles(args.properties)
+
+    ranked = sorted(chemicals_by_role.items(), key=lambda kv: (-len(kv[1]), kv[0]))
+    total_assertions = sum(len(chemicals) for chemicals in chemicals_by_role.values())
+    chemicals_with_a_role = {c for chemicals in chemicals_by_role.values() for c in chemicals}
+
+    with open(args.csv, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["role_curie", "role_label", "chemical_count"])
+        for role, chemicals in ranked:
+            writer.writerow([role, labels.get(role, ""), len(chemicals)])
+
+    with open(args.report, "w") as f:
+        f.write("# ChEBI role audit\n\n")
+        f.write(f"Source file: `{args.properties}`\n\n")
+        f.write(f"Roles are collected for descendants of {describe(CHEBI_ROLE_ROOT, labels)}.\n\n")
+        f.write(f"- Role assertions: {total_assertions:,}\n")
+        f.write(f"- Chemicals carrying at least one role: {len(chemicals_with_a_role):,}\n")
+        f.write(f"- Distinct roles: {len(chemicals_by_role):,}\n\n")
+        f.write(f"## The {REPORT_TOP_N} most-used roles\n\n")
+        f.write("Full ranking in [`role_counts.csv`](./role_counts.csv).\n\n")
+        f.write("| Role | Chemicals | Examples |\n| --- | ---: | --- |\n")
+        for role, chemicals in ranked[:REPORT_TOP_N]:
+            examples = ", ".join(describe(c, labels) for c in spread_examples(chemicals, EXAMPLES_PER_ROLE))
+            f.write(f"| {describe(role, labels)} | {len(chemicals):,} | {examples} |\n")
+
+    print(f"Wrote {args.report} and {args.csv}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/sources/CHEBI/sdf_tags/README.md
+++ b/docs/sources/CHEBI/sdf_tags/README.md
@@ -1,9 +1,15 @@
 # ChEBI SDF data-item tags
 
-`make_chebi_relations()` reads `ChEBI_complete.sdf` for four things: the ChEBI ID and name, the
-compound's secondary (obsoleted) identifiers, and its KEGG COMPOUND and PubChem Compound
-cross-references. It finds each of them by matching the SDF's data-item tags — `> <ChEBI ID>`,
-`> <SECONDARY_ID>` and so on — against a fixed list of expected names in `CHEBI_SDF_KEYS`.
+`make_chebi_relations()` reads `ChEBI_complete.sdf` for the ChEBI ID and name, the compound's
+secondary (obsoleted) identifiers, its KEGG COMPOUND and PubChem Compound cross-references, and its
+structure and physical-property values (`SMILES`, `INCHI`, `INCHIKEY`, `FORMULA`, `MASS`,
+`MONOISOTOPIC_MASS`, `CHARGE` — see [the structure properties
+section](../README.md#structure-properties)). It finds each of them by matching the SDF's data-item
+tags — `> <ChEBI ID>`, `> <SECONDARY_ID>` and so on — against a fixed list of expected names in
+`CHEBI_SDF_KEYS`.
+
+The tag audit below predates the structure properties, so its "Requested?" column marks only the
+seven keys that were consumed at the time; `inchikey` and `smiles` were then carried as canaries.
 
 ## Why this needs watching
 

--- a/docs/sources/CLAUDE.md
+++ b/docs/sources/CLAUDE.md
@@ -90,6 +90,41 @@ fact about the vocabularies and belongs where all of them can be seen at once. A
 depends on the local id (OMIM's `PS` phenotypic series) cannot be expressed in YAML; those are
 `LOCAL_ID_DEPENDENT_RENAMES` in `diseasephenotype.py`, and `norm()` takes the callable.
 
+### An UberGraph query that matches nothing looks exactly like a source with nothing to say
+
+SPARQL has no such thing as an unknown predicate. Ask for a property that has been renamed and you
+get an empty result set, not an error — so the ingest runs to completion, the build succeeds, and
+the field is simply absent for every term.
+
+This is the same failure as a renamed SDF tag (`docs/sources/CHEBI/sdf_tags/README.md`) and a
+reshaped TSV (`docs/sources/CHEBI/README.md`), on a third input. Both of those now raise; the
+SPARQL side did not, and `UberGraph.get_subclasses_and_smiles()` has been quietly returning SMILES
+for **zero** of ~194,000 ChEBI terms since ChEBI's structural annotations moved from
+`http://purl.obolibrary.org/obo/chebi/` to `https://w3id.org/chemrof/`
+([#1086](https://github.com/NCATSTranslator/Babel/issues/1086)). Nothing failed, and the loss was
+mostly masked downstream because another source happened to supply the same signal.
+
+So, for any query whose result feeds a build:
+
+- **Count what came back and raise on zero**, when the source cannot legitimately be empty.
+  `make_chebi_roles()` is the shape to copy. A count is the only check available here — there is no
+  "was this predicate recognized?" to ask.
+- **Probe the endpoint before trusting a predicate**, whether you are adding one or inheriting one.
+  One query settles it, and it is worth running against a predicate the repo has used for years:
+
+  ```sparql
+  select (count(*) as ?c) where { graph <http://reasoner.renci.org/ontology> { ?s <PREDICATE> ?o } }
+  ```
+
+- **Name a property after the vocabulary that publishes it**, so the name itself records where the
+  values came from and a later source switch changes nothing downstream — see the `CHEMROF_*`
+  constants in `src/predicates.py`.
+
+Note the masking, because it decides how much a passing build proves: a dead query costs nothing
+visible while some other source votes the same way, and surfaces only in the cliques where that
+source is absent. Agreement between sources is what hides this, so "the output still looks right"
+is not evidence the query works.
+
 ### Overuse filtering or a prefix exclusion?
 
 `remove_overused_xrefs` drops any target claimed by 2+ subjects. A prefix exclusion drops a

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -703,7 +703,11 @@ def write_compendium(
         write_compendium() will throw a RuntimeError if it is not specified. This is to ensure that it has been
         properly specified as a prerequisite in a Snakemake file, so that write_compendium() is not run until after
         icRDF.tsv has been generated.
-    :param properties_files: (OPTIONAL) A list of SQLite3 files containing properties to be added to the output.
+    :param properties_jsonl_gz_files: (OPTIONAL) A list of gzipped JSONL files of src.properties.Property
+        rows. Every property in them is loaded into an in-memory PropertyList, so pass only files
+        something here actually consumes -- today that is HAS_ALTERNATIVE_ID, used to splice
+        alternative identifiers into a clique. Annotation-only property files (ChEBI structure and
+        roles) are deliberately kept out of this list; see make_chebi_relations()'s docstring.
     :return:
     """
     logger.info(

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -29,6 +29,16 @@ from src.datahandlers.unichem import UNICHEM_REFERENCE_TSV_HEADER, UNICHEM_STRUC
 from src.datahandlers.unichem import data_sources as unichem_data_sources
 from src.datahandlers.unii import UNII_ORGANISM_COLUMNS, read_unii_records
 from src.metadata.provenance import write_combined_metadata, write_concord_metadata
+from src.predicates import (
+    CHEMROF_CHARGE,
+    CHEMROF_FORMULA,
+    CHEMROF_INCHI,
+    CHEMROF_INCHI_KEY,
+    CHEMROF_MASS,
+    CHEMROF_MONOISOTOPIC_MASS,
+    CHEMROF_SMILES,
+    HAS_ROLE,
+)
 from src.prefixes import (
     CHEBI,
     CHEMBLCOMPOUND,
@@ -71,22 +81,48 @@ CHEBI_SDF_KEY_SECONDARY_ID = "secondary_id"
 CHEBI_SDF_KEY_KEGG = "keggcompounddatabaselinks"
 CHEBI_SDF_KEY_PUBCHEM = "pubchemcompounddatabaselinks"
 
-# Only the three keys above are consumed by make_chebi_relations(). chebiid is what read_sdf() keys
-# its entries by, and chebiname/inchikey/smiles are carried purely as canaries: they cost nothing to
-# watch, and a rename that trips one of them says "ChEBI has reworked this file, re-audit all of it"
-# well before the rename lands on a tag we do consume. check_chebi_sdf_keys() fails the build on any
-# key in this set, canaries included -- that is deliberate. To stop watching one, delete it from here
-# rather than softening the check.
+# The SDF's structure and physical-property tags, mapped to the predicate each is written under.
+# These are emitted as Property rows into the structure property file; they take no part in concord
+# building or clique building.
+#
+# Named after ChemROF rather than ChEBI's own obo/chebi/ annotation properties because that is what
+# UberGraph now publishes these values under -- see src/predicates.py and issue #1086 -- so a
+# producer can later be switched from this SDF to UberGraph without changing the property file.
+CHEBI_SDF_STRUCTURE_PROPERTIES = {
+    "smiles": CHEMROF_SMILES,
+    "inchi": CHEMROF_INCHI,
+    "inchikey": CHEMROF_INCHI_KEY,
+    "formula": CHEMROF_FORMULA,
+    "mass": CHEMROF_MASS,
+    "monoisotopic_mass": CHEMROF_MONOISOTOPIC_MASS,
+    "charge": CHEMROF_CHARGE,
+}
+
+# Structure tags that are NOT covered by the per-key "produced no rows" guard below.
+#
+# That guard exists to catch a value-format change emptying an input silently, and it is only sound
+# for a tag ChEBI publishes for nearly every entry. The other six are on 94-100% of entries in the
+# 2026-06-29 SDF (181,048 to 192,445 of them), so zero rows really does mean something broke.
+# CHARGE is on 15,613 -- 8% -- because most ChEBI entries are uncharged and simply omit it. Guarding
+# it would be a check that can fire on legitimate data, so it is deliberately left out; a *rename*
+# of the CHARGE tag is still caught by check_chebi_sdf_keys(), which is the failure that actually
+# recurs here.
+CHEBI_SDF_SPARSE_STRUCTURE_KEYS = frozenset({"charge"})
+
+# chebiid is what read_sdf() keys its entries by, and chebiname is carried purely as a canary: it
+# costs nothing to watch, and a rename that trips it says "ChEBI has reworked this file, re-audit all
+# of it" well before the rename lands on a tag we do consume. check_chebi_sdf_keys() fails the build
+# on any key in this set, canaries included -- that is deliberate. To stop watching one, delete it
+# from here rather than softening the check.
 CHEBI_SDF_KEYS = frozenset(
     {
         "chebiid",
         "chebiname",
-        "inchikey",
-        "smiles",
         CHEBI_SDF_KEY_SECONDARY_ID,
         CHEBI_SDF_KEY_KEGG,
         CHEBI_SDF_KEY_PUBCHEM,
     }
+    | CHEBI_SDF_STRUCTURE_PROPERTIES.keys()
 )
 
 # How to read database_accession.tsv. `source_id` names the database ChEBI recorded a value from; for
@@ -858,10 +894,86 @@ def check_chebi_sdf_keys(chebi_sdf_dat, sdf):
         )
 
 
-def make_chebi_relations(sdf, dbx, dbx_source, dbx_status, outfile, propfile_gz, metadata_yaml):
+# The root whose descendants we collect ChEBI role assertions for. The same root write_chebi_ids()
+# walks, so the property file covers exactly the ChEBI terms the chemical pipeline knows about.
+#
+# Note that this deliberately does *not* cover the role terms themselves: CHEBI:50906 "role" is a
+# separate ChEBI root, not a descendant of CHEBI:24431, so roles are the values here and never the
+# subjects. Normalizing role terms as entities in their own right (biolink:ChemicalRole) is #101.
+CHEBI_ROLE_ROOT = f"{CHEBI}:24431"
+
+
+def make_chebi_roles(outfile_gz):
+    """
+    Write ChEBI's has_role (RO:0000087) assertions to a property file.
+
+    These are annotations on a chemical, not equivalence assertions, so they are written as
+    Property rows and take no part in concord or clique building. The values are role CURIEs that
+    Babel does not currently normalize as entities -- see issue #101.
+
+    No metadata YAML is written, matching the other property file this module produces.
+    write_concord_metadata() reads its subject as a three-column TSV to count prefix pairs, which a
+    gzipped JSONL property file is not; a property file's provenance is the `source` field carried
+    on every row.
+
+    :param outfile_gz: The gzipped JSONL property file to write.
+    :raise ValueError: If UberGraph returns no role assertions at all.
+    """
+    uber = UberGraph()
+    role_pairs = uber.get_roles(CHEBI_ROLE_ROOT)
+
+    # Guard the input, the way check_chebi_sdf_keys() and make_chebi_relations()'s per-input counts
+    # guard theirs. A SPARQL query against a predicate that has been renamed returns an empty result
+    # set rather than an error -- which is exactly how the CHEBIP:smiles lookup in
+    # get_subclasses_and_smiles() went quiet for every one of ~194,000 terms (issue #1086). An empty
+    # result here means the query is broken, not that ChEBI has stopped curating roles.
+    if not role_pairs:
+        raise ValueError(
+            f"UberGraph returned no {HAS_ROLE} assertions for descendants of {CHEBI_ROLE_ROOT}. "
+            f"ChEBI curates tens of thousands of these, so this is a broken query rather than an "
+            f"empty source -- check whether the predicate or the graph names have changed."
+        )
+
+    ensure_parent_dir(outfile_gz)
+    # Sorted so re-runs diff cleanly.
+    with gzip.open(outfile_gz, "wt") as outf:
+        for term, role in sorted(set(role_pairs)):
+            outf.write(
+                Property(
+                    curie=term,
+                    predicate=HAS_ROLE,
+                    value=role,
+                    source=f"Asserted as a ChEBI role ({HAS_ROLE}) of {term}, read from UberGraph",
+                ).to_json_line()
+            )
+
+    logger.info(f"make_chebi_roles() wrote {len(set(role_pairs))} role assertions to {outfile_gz}.")
+
+
+def make_chebi_relations(sdf, dbx, dbx_source, dbx_status, outfile, propfile_gz, structfile_gz, metadata_yaml):
     """CHEBI contains relations both about chemicals with and without inchikeys.  You might think that because
     everything is based on unichem, we could avoid the with structures part, but history has shown that we lose
-    links in that case, so we will use both the structured and unstructured chemical entries."""
+    links in that case, so we will use both the structured and unstructured chemical entries.
+
+    Writes three files: the xref concord, a property file of ChEBI secondary identifiers, and a
+    property file of the SDF's structure and physical-property values (SMILES, InChI, InChIKey,
+    formula, mass, monoisotopic mass, charge).
+
+    The structure properties go in their own file rather than into propfile_gz on purpose. That file
+    is an input to the chemical_compendia rule, which loads every property in it into an in-memory
+    PropertyList inside write_compendium(); nothing consumes structure properties yet, so folding
+    ~1.2M more of them into a rule already sized at 512G would buy nothing. When something does
+    consume them, adding this file to that rule's inputs is a one-line change.
+
+    :param sdf: ChEBI_complete.sdf.
+    :param dbx: database_accession.tsv.
+    :param dbx_source: source.tsv, for resolving dbx source_id to a database name.
+    :param dbx_status: status.tsv, for resolving dbx status_id to a curation state.
+    :param outfile: The xref concord to write.
+    :param propfile_gz: The gzipped JSONL property file for ChEBI secondary identifiers.
+    :param structfile_gz: The gzipped JSONL property file for the SDF's structure properties.
+    :param metadata_yaml: The concord metadata YAML to write.
+    """
     # THE SDF and XREF stuff are handled in the same function because knowing what we found in the SDF impacts
     # what we want to get out of the xrefs. But the function is quite unwieldy
     # READ SDF
@@ -883,6 +995,7 @@ def make_chebi_relations(sdf, dbx, dbx_source, dbx_status, outfile, propfile_gz,
 
     # What if we don't have a propfile directory?
     ensure_parent_dir(propfile_gz)
+    ensure_parent_dir(structfile_gz)
 
     # Output rows counted per source key rather than in aggregate. A total-count check does not
     # protect an individual input: the SDF's ~181,000 PubChem xrefs could vanish entirely and KEGG's
@@ -894,9 +1007,32 @@ def make_chebi_relations(sdf, dbx, dbx_source, dbx_status, outfile, propfile_gz,
     # the SDF's ~197,000 xrefs kept any whole-output guard quiet.
     dbx_key = "database_accession.tsv"
 
-    with open(outfile, "w") as outf, gzip.open(propfile_gz, "wt") as propf:
+    with open(outfile, "w") as outf, gzip.open(propfile_gz, "wt") as propf, gzip.open(structfile_gz, "wt") as structf:
         # Write SDF structured things
         for cid, props in chebi_sdf_dat.items():
+            for sdf_key, predicate in CHEBI_SDF_STRUCTURE_PROPERTIES.items():
+                if sdf_key not in props:
+                    continue
+                # Deliberately NOT split_chebi_sdf_values(). That splits on ";", which is a
+                # separator for a multi-valued *xref* tag but a legitimate character inside an
+                # InChI: a multi-component InChI uses it to separate per-component layers, as in
+                # `InChI=1S/2ClH.Ca/h2*1H;/q;;+2/p-2` for calcium chloride. Splitting here would
+                # shred 3,997 of the 181,048 InChI values in the 2026-06-29 SDF into fragments that
+                # are not InChIs at all. Every tag in this map is single-valued and, in that file,
+                # single-line; the lines are joined rather than indexed so a future wrapped value
+                # is concatenated instead of silently truncated to its first line.
+                value = "".join(line.strip() for line in props[sdf_key])
+                if not value:
+                    continue
+                structf.write(
+                    Property(
+                        curie=cid,
+                        predicate=predicate,
+                        value=value,
+                        source=f"Read from the {sdf_key} data item of the ChEBI SDF file ({sdf})",
+                    ).to_json_line()
+                )
+                counts[sdf_key] += 1
             if secondary_chebi_id in props:
                 # SECONDARY_ID holds already-prefixed CURIEs, semicolon-delimited on one line, e.g.
                 # CHEBI:421707 "abacavir" carries
@@ -950,9 +1086,11 @@ def make_chebi_relations(sdf, dbx, dbx_source, dbx_status, outfile, propfile_gz,
 
     # Backstop to check_chebi_sdf_keys(): that catches a renamed SDF tag, this catches the failures
     # a tag name cannot show -- a changed value format, a truncated download, a parse bug. ChEBI
-    # publishes all four of these in every release, so any one coming out empty means a silently
+    # publishes every one of these in every release, so any one coming out empty means a silently
     # broken build. Counted per input rather than in aggregate: both bugs this function has shipped
-    # were one input going quiet while the others kept a whole-output guard satisfied.
+    # were one input going quiet while the others kept a whole-output guard satisfied. The structure
+    # tags are checked on the same terms, except the sparse ones -- see
+    # CHEBI_SDF_SPARSE_STRUCTURE_KEYS for why CHARGE is exempt.
     #
     # The dbx count is of rows actually *written*, so it is zero either when that file is broken or,
     # in principle, when every one of its rows was skipped as already-structured. The second case is
@@ -962,13 +1100,21 @@ def make_chebi_relations(sdf, dbx, dbx_source, dbx_status, outfile, propfile_gz,
     # Both files have already been written and closed by this point, so the empty file exists on
     # disk when we raise; Snakemake deletes a failed job's outputs, but a direct call leaves it
     # behind. Hence "wrote an empty ..." rather than "refusing to write".
-    empty_keys = sorted(key for key in (secondary_chebi_id, kk, pk, dbx_key) if counts[key] == 0)
+    checked_keys = (
+        secondary_chebi_id,
+        kk,
+        pk,
+        dbx_key,
+        *(CHEBI_SDF_STRUCTURE_PROPERTIES.keys() - CHEBI_SDF_SPARSE_STRUCTURE_KEYS),
+    )
+    empty_keys = sorted(key for key in checked_keys if counts[key] == 0)
     if empty_keys:
         raise ValueError(
             f"ChEBI ingest from {sdf} and {dbx} produced no rows at all for: {empty_keys}. The SDF "
             f"tags themselves are present, so this is not a rename -- look for a changed value "
             f"format, a changed column layout, or a truncated download. Wrote empty output to "
-            f"{outfile} and {propfile_gz}; delete both and re-run once the cause is fixed."
+            f"{outfile}, {propfile_gz} and {structfile_gz}; delete them and re-run once the cause "
+            f"is fixed."
         )
     logger.info(f"make_chebi_relations() wrote {dict(counts)}.")
 

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -1218,38 +1218,20 @@ def build_untyped_compendia(
     dicts = read_partial_unichem(unichem_partial)
     types = {}
     for ifile in identifiers:
-        print(ifile)
+        logger.info(f"Glomming identifiers from {ifile}")
         new_identifiers, new_types = read_identifier_file(ifile)
         glom(dicts, new_identifiers, unique_prefixes=[INCHIKEY])
         types.update(new_types)
     for infile in concordances:
-        print(infile)
-        print("loading", infile)
+        logger.info(f"Glomming concord {infile}")
         pairs = []
         with open(infile) as inf:
             for line in inf:
                 x = line.strip().split("\t")
                 pairs.append([x[0], x[2]])
-        p = False
-        if DRUGCENTRAL in [n.split(":")[0] for n in pairs[0]]:
-            p = True
-            i = "DrugCentral:4970"
-        if p:
-            print("before filtering:")
-            for pair in pairs:
-                if i in pair:
-                    print(pair)
         newpairs = remove_overused_xrefs(pairs)
         setpairs = [set(x) for x in newpairs]
-        if p:
-            print("after filtering:")
-            for pair in newpairs:
-                if i in pair:
-                    print(pair)
         glom(dicts, setpairs, unique_prefixes=[INCHIKEY])
-        if p:
-            print("after glomming:")
-            print(dicts[i])
     with open(type_file, "w") as outf:
         for x, y in types.items():
             outf.write(f"{x}\t{y}\n")

--- a/src/exporters/duckdb_exporters.py
+++ b/src/exporters/duckdb_exporters.py
@@ -489,6 +489,7 @@ def export_intermediates_to_parquet(
     ids_parquet_filename,
     concords_parquet_filename,
     metadata_parquet_filename,
+    properties_parquet_filename,
     memory_limit_mb=None,
 ):
     """
@@ -504,6 +505,7 @@ def export_intermediates_to_parquet(
     :param ids_parquet_filename: The Parquet file to store the IDs.
     :param concords_parquet_filename: The Parquet file to store the concords.
     :param metadata_parquet_filename: The Parquet file to store the ID and concord metadata in.
+    :param properties_parquet_filename: The Parquet file to store the properties in.
     :param memory_limit_mb: DuckDB memory limit in MB. When set, overrides DuckDB's default
         (75% of system RAM), which can exceed the SLURM allocation on shared HPC nodes.
     """
@@ -511,7 +513,12 @@ def export_intermediates_to_parquet(
     _prepare_duckdb_output(duckdb_filename)
     # DuckDB's write_parquet won't create missing parent directories, so ensure each output's
     # directory exists -- this exporter is public and its Parquet paths need not share a directory.
-    for parquet_filename in (ids_parquet_filename, concords_parquet_filename, metadata_parquet_filename):
+    for parquet_filename in (
+        ids_parquet_filename,
+        concords_parquet_filename,
+        metadata_parquet_filename,
+        properties_parquet_filename,
+    ):
         ensure_parent_dir(parquet_filename)
 
     duckdb_config = {}
@@ -525,6 +532,9 @@ def export_intermediates_to_parquet(
         db.sql("""CREATE TABLE Identifier (filename STRING, curie STRING, biolink_type STRING)""")
         db.sql(
             """CREATE TABLE Metadata (filename STRING, subject_filename STRING, subject_file_path STRING, metadata_json STRING)"""
+        )
+        db.sql(
+            """CREATE TABLE Property (filename STRING, curie STRING, predicate STRING, value STRING, source STRING)"""
         )
 
         # Resolve to an absolute path so every `filename` value (and the metadata subject paths
@@ -605,6 +615,23 @@ def export_intermediates_to_parquet(
                 [str(ids_path)],
             )
 
+        # Load property files. These are gzipped JSONL of src.properties.Property, so unlike the
+        # concord and ids files they need no column guessing -- the four keys are fixed by
+        # Property.valid_keys(), and read_json's explicit `columns` makes a renamed or missing key
+        # fail loudly here rather than arriving as a column of NULLs.
+        for property_path, subject_filename in _iter_loadable_files(intermediate_path, "properties"):
+            if subject_filename is not None:
+                _insert_metadata(db, property_path, subject_filename)
+                continue
+            logger.info(f"Loading properties from {property_path}")
+            db.execute(
+                "INSERT INTO Property SELECT $1 AS filename, curie, predicate, value, source "
+                "FROM read_json($1, format='newline_delimited', "
+                "columns={'curie': 'VARCHAR', 'predicate': 'VARCHAR', 'value': 'VARCHAR', 'source': 'VARCHAR'})",
+                [str(property_path)],
+            )
+
         db.table("Concord").write_parquet(concords_parquet_filename)
         db.table("Identifier").write_parquet(ids_parquet_filename)
         db.table("Metadata").write_parquet(metadata_parquet_filename)
+        db.table("Property").write_parquet(properties_parquet_filename)

--- a/src/predicates.py
+++ b/src/predicates.py
@@ -32,6 +32,28 @@ RDFS_SUBCLASSOF = RDFS + "subClassOf"
 # OWL predicates
 OWL_EQUIVALENT_CLASS = OWL + "equivalentClass"
 
+# RO (Relations Ontology) predicates
+RO = "http://purl.obolibrary.org/obo/RO_"
+HAS_ROLE = RO + "0000087"
+
+# ChemROF predicates, for a chemical's structure and physical properties.
+#
+# These are the names UberGraph publishes ChEBI's structural annotations under. ChEBI used to
+# publish them under http://purl.obolibrary.org/obo/chebi/ (smiles, inchi, inchikey, formula,
+# monoisotopicmass); that namespace now has zero triples in UberGraph, which is issue #1086.
+#
+# We name our properties after the ChemROF URIs rather than the dead ChEBI ones, and rather than
+# minting Babel-local URIs, so that a producer can be switched from the ChEBI SDF to UberGraph (or
+# to another source that speaks ChemROF) without changing anything downstream of the property file.
+CHEMROF = "https://w3id.org/chemrof/"
+CHEMROF_SMILES = CHEMROF + "smiles_string"
+CHEMROF_INCHI = CHEMROF + "inchi_string"
+CHEMROF_INCHI_KEY = CHEMROF + "inchi_key_string"
+CHEMROF_FORMULA = CHEMROF + "generalized_empirical_formula"
+CHEMROF_MASS = CHEMROF + "mass"
+CHEMROF_MONOISOTOPIC_MASS = CHEMROF + "monoisotopic_mass"
+CHEMROF_CHARGE = CHEMROF + "charge"
+
 # Biolink predicates
 BIOLINK = "biolink:"
 BIOLINK_SAME_AS = BIOLINK + "same_as"

--- a/src/properties.py
+++ b/src/properties.py
@@ -13,7 +13,17 @@ import json
 from collections import defaultdict
 from dataclasses import dataclass
 
-from src.predicates import HAS_ALTERNATIVE_ID
+from src.predicates import (
+    CHEMROF_CHARGE,
+    CHEMROF_FORMULA,
+    CHEMROF_INCHI,
+    CHEMROF_INCHI_KEY,
+    CHEMROF_MASS,
+    CHEMROF_MONOISOTOPIC_MASS,
+    CHEMROF_SMILES,
+    HAS_ALTERNATIVE_ID,
+    HAS_ROLE,
+)
 
 #
 # SUPPORTED PROPERTIES
@@ -23,9 +33,24 @@ from src.predicates import HAS_ALTERNATIVE_ID
 # that should be included in the clique but NOT treated as a clique leader candidate.
 # Used for e.g. ChEBI secondary IDs or other deprecated identifiers.
 
+# HAS_ROLE: the role a chemical plays (ChEBI's RO:0000087 assertions). The value is a role CURIE,
+# and the roles themselves are not currently normalized as entities in their own right -- see #101.
+
+# CHEMROF_*: a chemical's structure and physical properties. One row per (CURIE, predicate, value),
+# because Property.value is a single str and Property is frozen so it can live in a set; a compound
+# with two values for a tag therefore produces two rows rather than one row holding a list.
+
 # Properties currently supported in the property store in one set for validation.
 supported_predicates = {
     HAS_ALTERNATIVE_ID,
+    HAS_ROLE,
+    CHEMROF_SMILES,
+    CHEMROF_INCHI,
+    CHEMROF_INCHI_KEY,
+    CHEMROF_FORMULA,
+    CHEMROF_MASS,
+    CHEMROF_MONOISOTOPIC_MASS,
+    CHEMROF_CHARGE,
 }
 
 #

--- a/src/snakefiles/chemical.snakefile
+++ b/src/snakefiles/chemical.snakefile
@@ -331,6 +331,7 @@ rule get_chebi_concord:
     output:
         outfile=config["intermediate_directory"] + "/chemicals/concords/CHEBI",
         propfile=config["intermediate_directory"] + "/chemicals/properties/get_chebi_concord.jsonl.gz",
+        structfile=config["intermediate_directory"] + "/chemicals/properties/chebi_structure.jsonl.gz",
         metadata_yaml=config["intermediate_directory"] + "/chemicals/concords/metadata-CHEBI.yaml",
     benchmark:
         config["output_directory"] + "/benchmarks/get_chebi_concord.tsv"
@@ -342,8 +343,21 @@ rule get_chebi_concord:
             input.dbx_status,
             output.outfile,
             propfile_gz=output.propfile,
+            structfile_gz=output.structfile,
             metadata_yaml=output.metadata_yaml,
         )
+
+
+# ChEBI role assertions. Deliberately not an input to chemical_compendia: these are annotations,
+# not equivalences, and nothing consumes them yet -- see make_chebi_roles()'s docstring.
+rule get_chebi_roles:
+    output:
+        outfile=config["intermediate_directory"] + "/chemicals/properties/chebi_roles.jsonl.gz",
+    benchmark:
+        config["output_directory"] + "/benchmarks/get_chebi_roles.tsv"
+    retries: 3
+    run:
+        chemicals.make_chebi_roles(output.outfile)
 
 
 rule chemical_unichem_concordia:
@@ -543,6 +557,13 @@ rule check_food:
 rule chemical:
     input:
         config["output_directory"] + "/reports/chemical_completeness.txt",
+        # Property files. Nothing downstream consumes these yet, so they are listed here rather than
+        # as an input to chemical_compendia -- that keeps them out of write_compendium()'s in-memory
+        # PropertyList while still making the build produce them.
+        properties=[
+            config["intermediate_directory"] + "/chemicals/properties/chebi_structure.jsonl.gz",
+            config["intermediate_directory"] + "/chemicals/properties/chebi_roles.jsonl.gz",
+        ],
         synonyms=expand("{od}/synonyms/{ap}", od=config["output_directory"], ap=config["chemical_outputs"]),
         reports=expand("{od}/reports/{ap}", od=config["output_directory"], ap=config["chemical_outputs"]),
         metadata=expand("{od}/metadata/{ap}.yaml", od=config["output_directory"], ap=config["chemical_outputs"]),

--- a/src/snakefiles/duckdb.snakefile
+++ b/src/snakefiles/duckdb.snakefile
@@ -150,6 +150,7 @@ rule export_intermediate_files_to_duckdb:
         ids_parquet_filename=config["output_directory"] + "/duckdb/Identifier.parquet",
         concord_parquet_filename=config["output_directory"] + "/duckdb/Concord.parquet",
         metadata_parquet_filename=config["output_directory"] + "/duckdb/Metadata.parquet",
+        properties_parquet_filename=config["output_directory"] + "/duckdb/Property.parquet",
     benchmark:
         config["output_directory"] + "/benchmarks/export_intermediate_files_to_duckdb.tsv"
     resources:
@@ -173,6 +174,7 @@ rule export_intermediate_files_to_duckdb:
             output.ids_parquet_filename,
             output.concord_parquet_filename,
             output.metadata_parquet_filename,
+            output.properties_parquet_filename,
             memory_limit_mb=duckdb_memory_limit_mb(resources.mem_mb),
         )
 

--- a/src/ubergraph.py
+++ b/src/ubergraph.py
@@ -424,6 +424,49 @@ class UberGraph:
             results.append(y)
         return results
 
+    def get_roles(self, iri):
+        """Return the ChEBI roles asserted for every descendant of `iri` that has one.
+
+        Queries the *non-redundant* graph, so each term carries only its directly asserted roles:
+        aspirin returns 13 there against 45 in the redundant graph, which is the same information
+        plus every ancestor of each role. Storing the redundant closure would multiply the row count
+        several-fold to say nothing new -- a consumer that wants ancestors can walk the role
+        hierarchy itself.
+
+        Terms with no role are not returned.
+
+        :param iri: The root whose descendants to collect roles for, as a CURIE (e.g. "CHEBI:24431").
+        :return: A list of (term CURIE, role CURIE) pairs.
+        """
+        text = """
+        prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        prefix RO: <http://purl.obolibrary.org/obo/RO_>
+        prefix CHEBI: <http://purl.obolibrary.org/obo/CHEBI_>
+        select distinct ?term ?role
+        from <http://reasoner.renci.org/ontology>
+        where {
+            graph <http://reasoner.renci.org/redundant> {
+                ?term rdfs:subClassOf $sourcedefclass .
+            }
+            graph <http://reasoner.renci.org/nonredundant> {
+                ?term RO:0000087 ?role .
+            }
+        }
+        """
+        rr = self.triplestore.query_template(
+            inputs={"sourcedefclass": iri}, outputs=["term", "role"], template_text=text
+        )
+        results = []
+        for x in rr:
+            try:
+                term = Text.opt_to_curie(x["term"])
+                role = Text.opt_to_curie(x["role"])
+            except ValueError as verr:
+                self.logger.warning(f"Skipping role assertion {x} that could not be converted to CURIEs: {verr}")
+                continue
+            results.append((term, role))
+        return results
+
     def get_subclasses_and_xrefs(self, iri, hierarchy_predicate=HIERARCHY_SUBCLASS_OF):
         """Return every term below `iri` in a hierarchy that has an xref, with its xrefs.
         Terms with no xref are not returned.

--- a/tests/createcompendia/test_chemicals.py
+++ b/tests/createcompendia/test_chemicals.py
@@ -25,6 +25,7 @@ from src.categories import (
 )
 from src.createcompendia.chemicals import (
     CHEBI_DBX_SOURCE_NAMES,
+    CHEBI_SDF_SPARSE_STRUCTURE_KEYS,
     create_typed_sets,
     make_chebi_relations,
     read_chebi_lookup_ids,
@@ -33,7 +34,16 @@ from src.createcompendia.chemicals import (
 )
 from src.datahandlers.unichem import UNICHEM_REFERENCE_TSV_HEADER, UNICHEM_STRUCT_TSV_HEADER
 from src.datahandlers.unichem import data_sources as unichem_data_sources
-from src.predicates import HAS_ALTERNATIVE_ID
+from src.predicates import (
+    CHEMROF_CHARGE,
+    CHEMROF_FORMULA,
+    CHEMROF_INCHI,
+    CHEMROF_INCHI_KEY,
+    CHEMROF_MASS,
+    CHEMROF_MONOISOTOPIC_MASS,
+    CHEMROF_SMILES,
+    HAS_ALTERNATIVE_ID,
+)
 from src.prefixes import CHEBI, KEGGCOMPOUND, PUBCHEMCOMPOUND
 from src.util import get_config
 
@@ -268,8 +278,23 @@ def test_create_typed_sets_leaves_a_clique_without_food_evidence_untouched():
 # babel_downloads/CHEBI/ChEBI_complete.sdf as downloaded for babel-1.18. It is the single record
 # that motivated this fix, and it happens to carry every tag make_chebi_relations() reads, so one
 # entry exercises all of CHEBI_SDF_KEYS. Re-derive it by extracting the chunk whose "> <ChEBI ID>"
-# tag holds CHEBI:421707.
+# tag holds CHEBI:421707. It carries every tag make_chebi_relations() reads except CHARGE, which
+# ChEBI omits for the 92% of entries that are uncharged -- see CHEBI_SDF_SPARSE_STRUCTURE_KEYS.
 ABACAVIR_SDF = Path(__file__).parent.parent / "data" / "chebi_abacavir.sdf"
+
+# tests/data/chebi_dioxouranium.sdf is the CHEBI:29124 "dioxouranium(1+)" entry, copied verbatim out
+# of the same file (2026-06-29 download). It is here for two things abacavir cannot show:
+#
+#   - it carries CHARGE, the one tag abacavir lacks, so the two together cover all of
+#     CHEBI_SDF_KEYS and check_chebi_sdf_keys() passes over the pair;
+#   - its InChI is "InChI=1S/2O.U/q;;+1". Those semicolons are part of the InChI -- a multi-component
+#     InChI uses ";" to separate per-component layers -- not the value separator they are in a
+#     multi-valued xref tag. 3,997 of the 181,048 InChIs in that SDF contain one, so a change that
+#     started routing structure values through split_chebi_sdf_values() would shred them all.
+#
+# It deliberately carries no KEGG COMPOUND, PubChem Compound or SECONDARY_ID tag, so adding it to
+# the default fixture leaves every concord and secondary-ID assertion below unchanged.
+DIOXOURANIUM_SDF = Path(__file__).parent.parent / "data" / "chebi_dioxouranium.sdf"
 
 # The header of database_accession.tsv, copied verbatim from
 # https://ftp.ebi.ac.uk/pub/databases/chebi/flat_files/database_accession.tsv.gz (fetched 2026-07-21).
@@ -307,14 +332,35 @@ STATUS_TSV = "id\tname\n1\tCHECKED\n3\tOK\n9\tSUBMITTED\n"
 DBX_SUBMITTED_KEGG_ROW = "1071122\t1690\tC05478\tMANUAL_X_REF\t9\t45\n"
 
 
+def _combined_sdf(tmp_path, *sdfs):
+    """Concatenate fixture SDFs into one file, the way real ChEBI entries sit in ChEBI_complete.sdf."""
+    combined = tmp_path / "combined.sdf"
+    combined.write_text(_default_sdf_text() if not sdfs else "".join(Path(s).read_text() for s in sdfs))
+    return combined
+
+
+def _default_sdf_text():
+    """The default fixture SDF's text: abacavir plus dioxouranium(1+).
+
+    Tests that mutate the SDF must start from both entries, not from abacavir alone -- otherwise
+    check_chebi_sdf_keys() fires on the missing CHARGE tag and masks whatever the test is asserting.
+    """
+    return ABACAVIR_SDF.read_text() + DIOXOURANIUM_SDF.read_text()
+
+
 def _run_make_chebi_relations(
     tmp_path,
-    sdf=ABACAVIR_SDF,
+    sdf=None,
     dbx_contents=DBX_HEADER + DBX_KEGG_ROW,
     source_contents=SOURCE_TSV,
     status_contents=STATUS_TSV,
 ):
-    """Run make_chebi_relations() over a fixture SDF, returning (concord lines, Property dicts)."""
+    """Run make_chebi_relations() over a fixture SDF.
+
+    Returns (concord lines, secondary-ID Property dicts, structure Property dicts).
+    """
+    if sdf is None:
+        sdf = _combined_sdf(tmp_path, ABACAVIR_SDF, DIOXOURANIUM_SDF)
     dbx = tmp_path / "database_accession.tsv"
     dbx.write_text(dbx_contents)
     dbx_source = tmp_path / "source.tsv"
@@ -323,6 +369,7 @@ def _run_make_chebi_relations(
     dbx_status.write_text(status_contents)
     concord = tmp_path / "CHEBI"
     propfile = tmp_path / "props.jsonl.gz"
+    structfile = tmp_path / "structure.jsonl.gz"
 
     make_chebi_relations(
         str(sdf),
@@ -331,12 +378,15 @@ def _run_make_chebi_relations(
         str(dbx_status),
         str(concord),
         propfile_gz=str(propfile),
+        structfile_gz=str(structfile),
         metadata_yaml=str(tmp_path / "metadata.yaml"),
     )
 
-    with gzip.open(propfile, "rt") as inf:
-        props = [json.loads(line) for line in inf]
-    return concord.read_text().splitlines(), props
+    def _read(path):
+        with gzip.open(path, "rt") as inf:
+            return [json.loads(line) for line in inf]
+
+    return concord.read_text().splitlines(), _read(propfile), _read(structfile)
 
 
 @pytest.mark.unit
@@ -347,7 +397,7 @@ def test_make_chebi_relations_emits_secondary_chebi_ids(tmp_path):
     value emits one nonsense CURIE instead of five real ones. CHEBI:520984 is the secondary ID that
     stopped normalizing in babel-1.18 when this ingest broke.
     """
-    _, props = _run_make_chebi_relations(tmp_path)
+    _, props, _ = _run_make_chebi_relations(tmp_path)
 
     secondary_ids = {p["value"] for p in props if p["predicate"] == HAS_ALTERNATIVE_ID}
     assert secondary_ids == {"CHEBI:193608", "CHEBI:441792", "CHEBI:2360", "CHEBI:525912", "CHEBI:520984"}
@@ -361,7 +411,7 @@ def test_make_chebi_relations_emits_kegg_and_pubchem_xrefs(tmp_path):
     PubChem is the regression-prone one: ChEBI split a single "PubChem Database Links" tag into
     separate Compound and Substance tags, and only the Compound side belongs in the concord.
     """
-    concord_lines, _ = _run_make_chebi_relations(tmp_path)
+    concord_lines, _, _ = _run_make_chebi_relations(tmp_path)
 
     assert f"CHEBI:421707\txref\t{KEGGCOMPOUND}:C07624" in concord_lines
     assert f"CHEBI:421707\txref\t{PUBCHEMCOMPOUND}:441300" in concord_lines
@@ -377,7 +427,7 @@ def test_make_chebi_relations_splits_multivalue_tags(tmp_path):
     Before the fix, a multi-value KEGG line produced "KEGG.COMPOUND:C00001;C00002", which matches
     nothing downstream and was invisible because it still looked like a populated concord.
     """
-    concord_lines, props = _run_make_chebi_relations(tmp_path)
+    concord_lines, props, _ = _run_make_chebi_relations(tmp_path)
 
     assert not any(";" in line for line in concord_lines)
     assert not any(";" in p["value"] for p in props)
@@ -407,7 +457,7 @@ def test_make_chebi_relations_raises_when_chebi_renames_a_tag(tmp_path, renamed_
     rename we tolerate is a rename nobody re-audits.
     """
     renamed = tmp_path / "renamed.sdf"
-    renamed.write_text(ABACAVIR_SDF.read_text().replace(renamed_tag, "> <Renamed By ChEBI>"))
+    renamed.write_text(_default_sdf_text().replace(renamed_tag, "> <Renamed By ChEBI>"))
 
     with pytest.raises(ValueError, match=expected_key):
         _run_make_chebi_relations(tmp_path, sdf=renamed)
@@ -436,7 +486,7 @@ def test_make_chebi_relations_raises_when_one_tag_yields_nothing(tmp_path, empti
     # Keep the tag line, blank the value, so check_chebi_sdf_keys() passes and this check is what
     # fires. The replaced text starts with the tag line for the two xref cases, so re-emit it.
     replacement = emptied_value.split("\n")[0] + "\n " if emptied_value.startswith("> <") else " "
-    emptied.write_text(ABACAVIR_SDF.read_text().replace(emptied_value, replacement))
+    emptied.write_text(_default_sdf_text().replace(emptied_value, replacement))
 
     with pytest.raises(ValueError, match=expected_key):
         _run_make_chebi_relations(tmp_path, sdf=emptied)
@@ -468,7 +518,7 @@ def test_make_chebi_relations_emits_database_accession_xrefs(tmp_path):
     column 3 against "KEGG COMPOUND accession", but that column is `type`, and it read the accession
     from `status_id`. It fired on 0 of 422,561 rows.
     """
-    concord_lines, _ = _run_make_chebi_relations(tmp_path, dbx_contents=DBX_HEADER + DBX_KEGG_ROW + DBX_PUBCHEM_ROW)
+    concord_lines, _, _ = _run_make_chebi_relations(tmp_path, dbx_contents=DBX_HEADER + DBX_KEGG_ROW + DBX_PUBCHEM_ROW)
 
     assert f"CHEBI:3\txref\t{KEGGCOMPOUND}:C06147" in concord_lines
     assert f"CHEBI:132338\txref\t{PUBCHEMCOMPOUND}:101936044" in concord_lines
@@ -484,7 +534,7 @@ def test_make_chebi_relations_ignores_non_accession_rows_of_a_wanted_source(tmp_
     source is the namespace. 10,476 rows in the real file are CAS numbers attributed to source_id 45,
     so reading source_id at face value would emit "KEGG.COMPOUND:498-15-7".
     """
-    concord_lines, _ = _run_make_chebi_relations(
+    concord_lines, _, _ = _run_make_chebi_relations(
         tmp_path, dbx_contents=DBX_HEADER + DBX_KEGG_ROW + DBX_CAS_ROW_UNDER_KEGG_SOURCE
     )
 
@@ -513,7 +563,7 @@ def test_make_chebi_relations_skips_dbx_rows_for_structured_chebis(tmp_path):
 
     # DBX_KEGG_ROW rides along so the dbx still contributes something; a dbx whose every row is
     # skipped trips the empty-input guard, which is the subject of the test below rather than this one.
-    concord_lines, _ = _run_make_chebi_relations(tmp_path, dbx_contents=DBX_HEADER + duplicate + DBX_KEGG_ROW)
+    concord_lines, _, _ = _run_make_chebi_relations(tmp_path, dbx_contents=DBX_HEADER + duplicate + DBX_KEGG_ROW)
 
     assert concord_lines.count(f"CHEBI:421707\txref\t{KEGGCOMPOUND}:C07624") == 1
 
@@ -527,7 +577,7 @@ def test_make_chebi_relations_ignores_submitted_dbx_rows(tmp_path):
     checked. 793 KEGG and 30 of the 55 PubChem rows are SUBMITTED, so excluding them costs little.
     Revisit if issue #957 establishes that SUBMITTED is verified some other way.
     """
-    concord_lines, _ = _run_make_chebi_relations(
+    concord_lines, _, _ = _run_make_chebi_relations(
         tmp_path, dbx_contents=DBX_HEADER + DBX_KEGG_ROW + DBX_SUBMITTED_KEGG_ROW
     )
 
@@ -574,3 +624,93 @@ def test_make_chebi_relations_raises_when_the_dbx_contributes_nothing(tmp_path):
     """
     with pytest.raises(ValueError, match="database_accession.tsv"):
         _run_make_chebi_relations(tmp_path, dbx_contents=DBX_HEADER)
+
+
+# CHEBI STRUCTURE PROPERTIES
+
+
+@pytest.mark.unit
+def test_make_chebi_relations_emits_structure_properties(tmp_path):
+    """Every structure tag in the SDF should reach the structure property file, under its ChemROF
+    predicate, keyed by the ChEBI the entry describes."""
+    _, _, structure = _run_make_chebi_relations(tmp_path)
+
+    abacavir = {p["predicate"]: p["value"] for p in structure if p["curie"] == "CHEBI:421707"}
+    assert abacavir == {
+        CHEMROF_SMILES: "Nc1nc(NC2CC2)c2ncn([C@H]3C=C[C@@H](CO)C3)c2n1",
+        CHEMROF_INCHI: "InChI=1S/C14H18N6O/c15-14-18-12(17-9-2-3-9)11-13(19-14)20(7-16-11)10-4-1-8(5-10)6-21/h1,4,7-10,21H,2-3,5-6H2,(H3,15,17,18,19)/t8-,10+/m1/s1",
+        CHEMROF_INCHI_KEY: "MCGSCOLBFJQGHM-SCZZXKLOSA-N",
+        CHEMROF_FORMULA: "C14H18N6O",
+        CHEMROF_MASS: "286.339",
+        CHEMROF_MONOISOTOPIC_MASS: "286.15421",
+    }
+
+
+@pytest.mark.unit
+def test_make_chebi_relations_does_not_split_inchis_on_semicolons(tmp_path):
+    """An InChI's semicolons are part of the value, not a value separator.
+
+    A multi-component InChI uses ";" to separate per-component layers, so routing structure values
+    through split_chebi_sdf_values() -- which is correct for a multi-valued xref tag -- would shred
+    3,997 of the 181,048 InChIs in the 2026-06-29 SDF into fragments that are not InChIs at all.
+    This is the same shape as the NCBIGene double-prime bug, where a plausible-looking cleanup
+    discarded ~4,000 real values.
+    """
+    _, _, structure = _run_make_chebi_relations(tmp_path)
+
+    inchis = [p["value"] for p in structure if p["curie"] == "CHEBI:29124" and p["predicate"] == CHEMROF_INCHI]
+    assert inchis == ["InChI=1S/2O.U/q;;+1"]
+
+
+@pytest.mark.unit
+def test_make_chebi_relations_emits_charge_only_where_present(tmp_path):
+    """CHARGE is on 8% of real entries, so it must be emitted where present and simply absent
+    elsewhere -- never defaulted to 0, which would assert a fact ChEBI did not state."""
+    _, _, structure = _run_make_chebi_relations(tmp_path)
+
+    charges = {p["curie"]: p["value"] for p in structure if p["predicate"] == CHEMROF_CHARGE}
+    assert charges == {"CHEBI:29124": "1"}
+
+
+@pytest.mark.unit
+def test_make_chebi_relations_keeps_structure_out_of_the_secondary_id_property_file(tmp_path):
+    """The two property files are separate on purpose: only the secondary-ID one is loaded into
+    write_compendium()'s in-memory PropertyList, so structure must not leak into it."""
+    _, props, structure = _run_make_chebi_relations(tmp_path)
+
+    assert {p["predicate"] for p in props} == {HAS_ALTERNATIVE_ID}
+    assert HAS_ALTERNATIVE_ID not in {p["predicate"] for p in structure}
+    assert structure, "expected the structure property file to be non-empty"
+
+
+@pytest.mark.unit
+def test_make_chebi_relations_raises_when_a_dense_structure_tag_yields_nothing(tmp_path):
+    """A structure tag that is present but yields no values should fail the build, naming the tag.
+
+    check_chebi_sdf_keys() cannot see this -- the tag is still there, only its values stopped
+    parsing. That is precisely how the CHEBIP:smiles lookup went quiet elsewhere (issue #1086).
+    """
+    emptied = tmp_path / "emptied.sdf"
+    emptied.write_text(
+        _default_sdf_text()
+        .replace("> <FORMULA>\nC14H18N6O", "> <FORMULA>\n ")
+        .replace("> <FORMULA>\nO2U", "> <FORMULA>\n ")
+    )
+
+    with pytest.raises(ValueError, match="formula"):
+        _run_make_chebi_relations(tmp_path, sdf=emptied)
+
+
+@pytest.mark.unit
+def test_make_chebi_relations_does_not_guard_sparse_structure_tags(tmp_path):
+    """CHARGE is absent from 92% of real entries, so an empty CHARGE must not fail the build --
+    a guard that can fire on legitimate data is worse than no guard. A CHARGE *rename* is still
+    caught by check_chebi_sdf_keys()."""
+    assert "charge" in CHEBI_SDF_SPARSE_STRUCTURE_KEYS
+
+    emptied = tmp_path / "emptied.sdf"
+    emptied.write_text(_default_sdf_text().replace("> <CHARGE>\n1", "> <CHARGE>\n "))
+
+    # Does not raise, and simply emits no charge rows.
+    _, _, structure = _run_make_chebi_relations(tmp_path, sdf=emptied)
+    assert [p for p in structure if p["predicate"] == CHEMROF_CHARGE] == []

--- a/tests/createcompendia/test_chemicals.py
+++ b/tests/createcompendia/test_chemicals.py
@@ -9,6 +9,7 @@ reading of the ChEBI SDF, whose tags ChEBI renames between releases.
 import gzip
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -23,11 +24,14 @@ from src.categories import (
     POLYPEPTIDE,
     SMALL_MOLECULE,
 )
+from src.createcompendia import chemicals
 from src.createcompendia.chemicals import (
     CHEBI_DBX_SOURCE_NAMES,
+    CHEBI_ROLE_ROOT,
     CHEBI_SDF_SPARSE_STRUCTURE_KEYS,
     create_typed_sets,
     make_chebi_relations,
+    make_chebi_roles,
     read_chebi_lookup_ids,
     split_chebi_sdf_values,
     write_unichem_concords,
@@ -43,6 +47,7 @@ from src.predicates import (
     CHEMROF_MONOISOTOPIC_MASS,
     CHEMROF_SMILES,
     HAS_ALTERNATIVE_ID,
+    HAS_ROLE,
 )
 from src.prefixes import CHEBI, KEGGCOMPOUND, PUBCHEMCOMPOUND
 from src.util import get_config
@@ -714,3 +719,67 @@ def test_make_chebi_relations_does_not_guard_sparse_structure_tags(tmp_path):
     # Does not raise, and simply emits no charge rows.
     _, _, structure = _run_make_chebi_relations(tmp_path, sdf=emptied)
     assert [p for p in structure if p["predicate"] == CHEMROF_CHARGE] == []
+
+
+# CHEBI ROLES
+
+
+def _run_make_chebi_roles(tmp_path, role_pairs):
+    """Run make_chebi_roles() with UberGraph.get_roles() returning `role_pairs`."""
+    outfile = tmp_path / "chebi_roles.jsonl.gz"
+    with patch.object(chemicals, "UberGraph") as mock_uber:
+        mock_uber.return_value.get_roles.return_value = role_pairs
+        make_chebi_roles(str(outfile))
+        mock_uber.return_value.get_roles.assert_called_once_with(CHEBI_ROLE_ROOT)
+
+    with gzip.open(outfile, "rt") as inf:
+        return [json.loads(line) for line in inf]
+
+
+@pytest.mark.unit
+def test_make_chebi_roles_writes_one_property_per_assertion(tmp_path):
+    """Each (chemical, role) pair becomes a HAS_ROLE property whose value is the role CURIE."""
+    props = _run_make_chebi_roles(tmp_path, [("CHEBI:15365", "CHEBI:35475"), ("CHEBI:15365", "CHEBI:35493")])
+
+    assert {p["predicate"] for p in props} == {HAS_ROLE}
+    assert {(p["curie"], p["value"]) for p in props} == {
+        ("CHEBI:15365", "CHEBI:35475"),
+        ("CHEBI:15365", "CHEBI:35493"),
+    }
+    assert all(p["source"] for p in props), "every property should say where it came from"
+
+
+@pytest.mark.unit
+def test_make_chebi_roles_deduplicates_and_sorts(tmp_path):
+    """Output is sorted and duplicate-free so that re-runs diff cleanly.
+
+    UberGraph's result order is not guaranteed, and build_sets() has already been bitten by
+    nondeterministic UberGraph ordering (#902) -- a property file that reshuffles between runs makes
+    every build-to-build comparison noisy for no reason.
+    """
+    pairs = [
+        ("CHEBI:16236", "CHEBI:75771"),
+        ("CHEBI:15365", "CHEBI:35475"),
+        ("CHEBI:16236", "CHEBI:75771"),  # exact duplicate
+        ("CHEBI:15365", "CHEBI:25212"),
+    ]
+    props = _run_make_chebi_roles(tmp_path, pairs)
+
+    assert [(p["curie"], p["value"]) for p in props] == [
+        ("CHEBI:15365", "CHEBI:25212"),
+        ("CHEBI:15365", "CHEBI:35475"),
+        ("CHEBI:16236", "CHEBI:75771"),
+    ]
+
+
+@pytest.mark.unit
+def test_make_chebi_roles_raises_when_ubergraph_returns_nothing(tmp_path):
+    """An empty result must fail the build rather than write an empty file.
+
+    SPARQL has no unknown-predicate error: a renamed predicate returns an empty result set, which is
+    indistinguishable from "ChEBI curates no roles". That is exactly how the CHEBIP:smiles lookup in
+    get_subclasses_and_smiles() went quiet for ~194,000 terms (#1086), so this is the one check
+    available here.
+    """
+    with pytest.raises(ValueError, match="no .* assertions"):
+        _run_make_chebi_roles(tmp_path, [])

--- a/tests/data/chebi_dioxouranium.sdf
+++ b/tests/data/chebi_dioxouranium.sdf
@@ -1,0 +1,55 @@
+
+  Marvin  12070522092D          
+
+  3  2  0  0  0  0            999 V2000
+    0.0000    0.8250    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000   -0.8250    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    0.0000    0.0000 U   0  3  0  0  0  0  0  0  0  0  0  0
+  3  1  2  0  0  0  0
+  3  2  2  0  0  0  0
+M  CHG  1   3   1
+M  END
+
+> <ChEBI ID>
+CHEBI:29124
+
+> <ChEBI NAME>
+dioxouranium(1+)
+
+> <STAR>
+3
+
+> <MASS>
+270.027
+
+> <FORMULA>
+O2U
+
+> <MONOISOTOPIC_MASS>
+270.04007
+
+> <CHARGE>
+1
+
+> <SMILES>
+[O]=[U+]=[O]
+
+> <INCHI>
+InChI=1S/2O.U/q;;+1
+
+> <INCHIKEY>
+AXQFOSFQUUEWOE-UHFFFAOYSA-N
+
+> <IUPAC_NAME>
+dioxidouranium(1+);dioxidouranium(V);dioxidouranium(V);dioxidouranium(1+)
+
+> <SYNONYM>
+UO2(+);[UO2](+);dioxouranium(1+);dioxouranium(V);uranyl(1+) ion;uranyl(1+);uranyl(V) cation
+
+> <Gmelin Registry Numbers>
+1892
+
+> <PubChem Substance Database Links>
+8146717
+
+$$$$

--- a/tests/test_duckdb_exporters.py
+++ b/tests/test_duckdb_exporters.py
@@ -1,3 +1,4 @@
+import gzip
 import json
 import os
 
@@ -11,6 +12,8 @@ from src.exporters.duckdb_exporters import (
     export_intermediates_to_parquet,
     log_duckdb_settings_on_error,
 )
+from src.predicates import CHEMROF_FORMULA, CHEMROF_INCHI
+from src.properties import Property
 from tests.conftest import CONFLATION_FIXTURE_ROWS
 
 # A minimal two-clique compendium in the same format write_compendium() produces.
@@ -195,6 +198,21 @@ def _build_intermediate_tree(intermediate_dir):
     (ids_dir / "CHEBI").write_text("CHEBI:1\tbiolink:SmallMolecule\nCHEBI:2\tbiolink:SmallMolecule\n")
     (ids_dir / "PLAIN").write_text("PLAIN:1\nPLAIN:2\n")
 
+    # A gzipped JSONL property file. The InChI value carries the semicolons a multi-component InChI
+    # really uses, so a future change that starts splitting property values on ";" fails here.
+    properties_dir = intermediate_dir / "datacollect" / "properties"
+    properties_dir.mkdir(parents=True)
+    with gzip.open(properties_dir / "structure.jsonl.gz", "wt") as f:
+        f.write(
+            Property(
+                curie="CHEBI:3312",
+                predicate=CHEMROF_INCHI,
+                value="InChI=1S/2ClH.Ca/h2*1H;/q;;+2/p-2",
+                source="test",
+            ).to_json_line()
+        )
+        f.write(Property(curie="CHEBI:3312", predicate=CHEMROF_FORMULA, value="CaCl2", source="test").to_json_line())
+
     return intermediate_dir
 
 
@@ -205,8 +223,11 @@ def test_export_intermediates_to_parquet(tmp_path):
     ids_parquet = str(tmp_path / "Identifier.parquet")
     concords_parquet = str(tmp_path / "Concord.parquet")
     metadata_parquet = str(tmp_path / "Metadata.parquet")
+    properties_parquet = str(tmp_path / "Property.parquet")
 
-    export_intermediates_to_parquet(str(intermediate_dir), duckdb_file, ids_parquet, concords_parquet, metadata_parquet)
+    export_intermediates_to_parquet(
+        str(intermediate_dir), duckdb_file, ids_parquet, concords_parquet, metadata_parquet, properties_parquet
+    )
 
     # Concords: both rows loaded, and the embedded double quote is preserved literally
     # (quote='' on read_csv).
@@ -227,6 +248,15 @@ def test_export_intermediates_to_parquet(tmp_path):
         ("CHEBI:2", "biolink:SmallMolecule"),
         ("PLAIN:1", None),
         ("PLAIN:2", None),
+    ]
+
+    # Property: both rows loaded, and the InChI's semicolons survive intact.
+    properties = duckdb.execute(
+        f"SELECT curie, predicate, value FROM read_parquet('{properties_parquet}') ORDER BY predicate"
+    ).fetchall()
+    assert properties == [
+        ("CHEBI:3312", CHEMROF_FORMULA, "CaCl2"),
+        ("CHEBI:3312", CHEMROF_INCHI, "InChI=1S/2ClH.Ca/h2*1H;/q;;+2/p-2"),
     ]
 
     # Metadata: the sidecar describing Anatomy.txt resolves its subject filename, and the bare
@@ -257,12 +287,14 @@ def test_export_intermediates_to_parquet_filename_is_absolute(tmp_path, monkeypa
     concords_parquet = str(tmp_path / "Concord.parquet")
     ids_parquet = str(tmp_path / "Identifier.parquet")
     metadata_parquet = str(tmp_path / "Metadata.parquet")
+    properties_parquet = str(tmp_path / "Property.parquet")
     export_intermediates_to_parquet(
         "intermediate",  # deliberately relative
         str(tmp_path / "concords.duckdb"),
         ids_parquet,
         concords_parquet,
         metadata_parquet,
+        properties_parquet,
     )
 
     for parquet_file, columns in (
@@ -295,12 +327,14 @@ def test_export_intermediates_to_parquet_extensionless_concords_with_sidecar(tmp
 
     concords_parquet = str(tmp_path / "Concord.parquet")
     metadata_parquet = str(tmp_path / "Metadata.parquet")
+    properties_parquet = str(tmp_path / "Property.parquet")
     export_intermediates_to_parquet(
         str(intermediate_dir),
         str(tmp_path / "concords.duckdb"),
         str(tmp_path / "Identifier.parquet"),
         concords_parquet,
         metadata_parquet,
+        properties_parquet,
     )
 
     # Both extension-less data files are loaded; the sidecar's contents are not among them.
@@ -331,8 +365,11 @@ def test_export_intermediates_to_parquet_empty_tree(tmp_path):
     ids_parquet = str(tmp_path / "Identifier.parquet")
     concords_parquet = str(tmp_path / "Concord.parquet")
     metadata_parquet = str(tmp_path / "Metadata.parquet")
+    properties_parquet = str(tmp_path / "Property.parquet")
 
-    export_intermediates_to_parquet(str(intermediate_dir), duckdb_file, ids_parquet, concords_parquet, metadata_parquet)
+    export_intermediates_to_parquet(
+        str(intermediate_dir), duckdb_file, ids_parquet, concords_parquet, metadata_parquet, properties_parquet
+    )
 
     for parquet_file in (ids_parquet, concords_parquet, metadata_parquet):
         count = duckdb.execute(f"SELECT COUNT(*) FROM read_parquet('{parquet_file}')").fetchone()[0]
@@ -352,6 +389,7 @@ def test_export_intermediates_to_parquet_raises_on_existing_duckdb(tmp_path):
             str(tmp_path / "Identifier.parquet"),
             str(tmp_path / "Concord.parquet"),
             str(tmp_path / "Metadata.parquet"),
+            str(tmp_path / "Property.parquet"),
         )
 
 
@@ -370,6 +408,7 @@ def test_export_intermediates_to_parquet_inconsistent_columns(tmp_path):
             str(tmp_path / "Identifier.parquet"),
             str(tmp_path / "Concord.parquet"),
             str(tmp_path / "Metadata.parquet"),
+            str(tmp_path / "Property.parquet"),
         )
 
 
@@ -397,6 +436,7 @@ def test_export_intermediates_to_parquet_skips_malformed_concord_line(tmp_path, 
             str(tmp_path / "Identifier.parquet"),
             concords_parquet,
             str(tmp_path / "Metadata.parquet"),
+            str(tmp_path / "Property.parquet"),
         )
 
     concords = duckdb.execute(
@@ -431,6 +471,7 @@ def test_export_intermediates_to_parquet_malformed_concord_attributed_to_right_f
             str(tmp_path / "Identifier.parquet"),
             concords_parquet,
             str(tmp_path / "Metadata.parquet"),
+            str(tmp_path / "Property.parquet"),
         )
 
     # All three well-formed rows load; only C:2's malformed line is dropped.
@@ -457,9 +498,15 @@ def test_export_intermediates_to_parquet_creates_missing_output_dirs(tmp_path):
     ids_parquet = str(out / "Identifier.parquet")
     concords_parquet = str(out / "Concord.parquet")
     metadata_parquet = str(out / "Metadata.parquet")
+    properties_parquet = str(out / "Property.parquet")
 
     export_intermediates_to_parquet(
-        str(intermediate_dir), str(tmp_path / "concords.duckdb"), ids_parquet, concords_parquet, metadata_parquet
+        str(intermediate_dir),
+        str(tmp_path / "concords.duckdb"),
+        ids_parquet,
+        concords_parquet,
+        metadata_parquet,
+        properties_parquet,
     )
 
     for parquet_file in (ids_parquet, concords_parquet, metadata_parquet):

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,0 +1,93 @@
+"""Unit tests for src.properties.
+
+Property's only validation gate is `supported_predicates`, so these cover what that set admits and
+rejects, and that a value survives the JSONL round trip unaltered -- which matters most for the
+chemical structure properties, whose values carry characters (semicolons, slashes, brackets,
+backslashes) that a naive serializer or splitter would mangle.
+"""
+
+import gzip
+
+import pytest
+
+from src.predicates import (
+    CHEMROF_CHARGE,
+    CHEMROF_FORMULA,
+    CHEMROF_INCHI,
+    CHEMROF_INCHI_KEY,
+    CHEMROF_MASS,
+    CHEMROF_MONOISOTOPIC_MASS,
+    CHEMROF_SMILES,
+    HAS_ALTERNATIVE_ID,
+    HAS_ROLE,
+)
+from src.properties import Property, PropertyList, supported_predicates
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "predicate",
+    [
+        HAS_ALTERNATIVE_ID,
+        HAS_ROLE,
+        CHEMROF_SMILES,
+        CHEMROF_INCHI,
+        CHEMROF_INCHI_KEY,
+        CHEMROF_FORMULA,
+        CHEMROF_MASS,
+        CHEMROF_MONOISOTOPIC_MASS,
+        CHEMROF_CHARGE,
+    ],
+)
+def test_supported_predicates_are_constructible(predicate):
+    """Every predicate in the supported set must actually pass Property's own gate."""
+    assert predicate in supported_predicates
+    assert Property(curie="CHEBI:1", predicate=predicate, value="x").predicate == predicate
+
+
+@pytest.mark.unit
+def test_unsupported_predicate_raises():
+    """The gate is the only thing standing between a typo'd predicate and a property file nothing
+    can query, so it must fail loudly rather than accept an unknown URI."""
+    with pytest.raises(ValueError, match="not supported"):
+        Property(curie="CHEBI:1", predicate="https://example.org/made-up", value="x")
+
+
+@pytest.mark.unit
+def test_structure_values_survive_the_jsonl_round_trip(tmp_path):
+    """A structure value must come back byte-identical.
+
+    The InChI here is a real multi-component one -- its semicolons separate per-component layers and
+    are part of the value. The SMILES carries backslashes and brackets. Both are the kind of string
+    a line-based format mishandles quietly.
+    """
+    written = [
+        Property(curie="CHEBI:29124", predicate=CHEMROF_INCHI, value="InChI=1S/2O.U/q;;+1", source="t"),
+        Property(curie="CHEBI:3312", predicate=CHEMROF_SMILES, value=r"C/C=C\[N+]([O-])=O.[Na+]", source="t"),
+    ]
+    path = tmp_path / "props.jsonl.gz"
+    with gzip.open(path, "wt") as f:
+        for prop in written:
+            f.write(prop.to_json_line())
+
+    pl = PropertyList()
+    assert pl.add_properties_jsonl_gz(str(path)) == 2
+    assert pl.properties == set(written)
+    assert {p.value for p in pl.get_all("CHEBI:29124", CHEMROF_INCHI)} == {"InChI=1S/2O.U/q;;+1"}
+
+
+@pytest.mark.unit
+def test_same_curie_carries_several_predicates():
+    """Property.value is a single str, so a chemical's several structure facts are several rows;
+    get_all() must be able to separate them again."""
+    pl = PropertyList()
+    pl.add_properties(
+        {
+            Property(curie="CHEBI:29124", predicate=CHEMROF_FORMULA, value="O2U"),
+            Property(curie="CHEBI:29124", predicate=CHEMROF_CHARGE, value="1"),
+            Property(curie="CHEBI:29124", predicate=HAS_ROLE, value="CHEBI:75771"),
+        }
+    )
+
+    assert len(pl.get_all("CHEBI:29124")) == 3
+    assert {p.value for p in pl.get_all("CHEBI:29124", CHEMROF_CHARGE)} == {"1"}

--- a/tests/test_uber.py
+++ b/tests/test_uber.py
@@ -78,3 +78,29 @@ def test_get_sub_exact_no_exact(ubergraph):
     assert k in subs
     assert len(subs[k]) == 0
     print(subs)
+
+
+def test_get_roles_returns_chebi_role_assertions(ubergraph):
+    """get_roles() should return ChEBI's directly asserted RO:0000087 roles for a branch.
+
+    Asserted against CHEBI:35366 "fatty acid" rather than the whole chemical-entity root so the
+    query stays cheap. The specific check is that the *non-redundant* graph is used: aspirin has 13
+    directly asserted roles against 45 in the redundant graph, and storing the closure would
+    multiply the row count to say nothing new.
+    """
+    with _server_errors_are_xfail():
+        pairs = ubergraph.get_roles("CHEBI:35366")
+
+    assert pairs, "expected ChEBI to assert roles for descendants of CHEBI:35366"
+    # Every pair is (term CURIE, role CURIE), both ChEBI, and no term is its own role.
+    for term, role in pairs:
+        assert term.startswith("CHEBI:"), term
+        assert role.startswith("CHEBI:"), role
+        assert term != role
+
+    # A role's own ancestors must not be present: that is what the non-redundant graph buys.
+    # CHEBI:25212 "metabolite" is asserted on many fatty acids; its ancestor CHEBI:33232
+    # "application" is not asserted on any of them.
+    roles = {role for _, role in pairs}
+    assert "CHEBI:25212" in roles
+    assert "CHEBI:33232" not in roles


### PR DESCRIPTION
## Summary

ChEBI publishes a chemical's structure and its roles, and Babel was throwing both away. This adds them to the property store as standalone build artifacts, queryable through DuckDB, without touching the compendia.

- **1,147,042 structure properties** from `ChEBI_complete.sdf` — SMILES, InChI, InChIKey, formula, mass, monoisotopic mass, charge.
- **42,918 role assertions** (`RO:0000087`) over 24,807 chemicals and 1,377 distinct roles, from UberGraph.

Two of those SDF tags (`inchikey`, `smiles`) were already being parsed as rename canaries, with their values read and discarded.

## What this does to existing cliques

**Nothing, by construction.** The new property files are inputs to `rule chemical`, not to `chemical_compendia`, so `write_compendium()`'s in-memory `PropertyList` is unchanged and no compendium byte moves. The diff of `chemical.snakefile` shows `chemical_compendia`'s `properties_jsonl_gz` line untouched.

That is deliberate rather than incidental. Nothing consumes structure properties yet, and folding ~1.2M more of them into a rule already sized at 512 GB would buy nothing. Adding a file to that rule's inputs later is one line.

## Why bother now

Several open issues are stuck for want of exactly this data:

- **#452 / #230** — cliques split because two InChIKeys differ only in the stereo layer. Now checkable in one query: `CHEBI:4305` and `CHEBI:177836` "dacarbazine" both come out as `FDKXTQMXEQVLRF-*` with formula `C6H10N6O`.
- **Feedback#1388** — the mirror image, where PubChem and HMDB give a *class* term an InChIKey and `glom()` over-merges. ChEBI handles those correctly with an R-group SMILES, which is now stored.
- **#83** — `create_typed_sets`' `{SmallMolecule, MolecularMixture}` split carries a comment naming SMILES and molecular formula as the un-done comprehensive fix.
- **#871** (InChIs) and **#101** (roles) — this is the annotation half of both; I've updated those issues with what changed.

## Judgement calls for review

- [ ] **Structure values are not run through `split_chebi_sdf_values()`.** Splitting on `;` is right for a multi-valued xref tag and wrong here: a multi-component InChI uses `;` to separate per-component layers, as in [`CHEBI:29124`](http://purl.obolibrary.org/obo/CHEBI_29124) "dioxouranium(1+)" = `InChI=1S/2O.U/q;;+1`. 3,997 of the 181,048 InChIs in the 2026-06-29 SDF contain one, so splitting would shred every one — the same shape as the NCBIGene double-prime bug. `tests/data/chebi_dioxouranium.sdf` is a verbatim copy of that entry and pins it.
- [ ] **`CHARGE` is exempt from the per-input "produced no rows" guard.** It is on 8% of entries because most ChEBI entries are uncharged and simply omit it, so guarding it would be a check that fires on legitimate data. A `CHARGE` *rename* is still caught by `check_chebi_sdf_keys()`. The other six tags are on 94–100% of entries and are guarded.
- [ ] **Roles come from the non-redundant graph.** Aspirin has 13 directly asserted roles there against 45 in the redundant graph; the extra 32 are ancestors of those 13. A consumer wanting ancestors can walk the hierarchy.
- [ ] **Predicates are named after ChemROF, not ChEBI's own `obo/chebi/` annotation properties.** ChEBI used to publish these under the latter; UberGraph now has zero triples there (#1086). Naming ours after the live vocabulary means a later switch of producer from the SDF to UberGraph changes nothing downstream.

## Found along the way

**#1086 — `get_subclasses_and_smiles()` has been silently returning nothing.** It queries `CHEBIP:smiles`, which has zero triples in UberGraph; ChEBI's structural annotations moved to ChemROF. ~194,000 ChEBI terms contribute no SMILES-derived type, mostly masked because PubChem votes the same way. Filed rather than fixed here: repointing it retypes cliques and needs its own clique-diff and SME sign-off. This PR's `CHEMROF_*` constants are what that fix will use.

Also filed: **#1085** (mapping atomic numbers to ChEBI — there is no derivation, it has to be curated) and **#1087** (`sample_name_pairs()` spends its draw budget on repeat draws).

## TODO before merge

- [ ] **Run both rules under Snakemake.** `make_chebi_relations()` and `make_chebi_roles()` have so far only been called directly against the on-disk ChEBI download; the rules themselves are `-n` dry-run verified only. In particular `get_chebi_roles` has no `resources:` block, so it takes the SLURM 64 GB / 120 min default for a query spanning ~200,000 terms — plausible but unmeasured. Size it from a real run's benchmark.

## Implementation notes

None of this changes the answers above.

- `src/properties.py`'s `supported_predicates` is the only validation gate; the eight new predicates are added there and in `src/predicates.py`.
- `Property.parquet` joins `Concord`/`Identifier`/`Metadata` in the intermediate DuckDB sweep. Property files are JSONL with fixed keys, so `read_json` gets an explicit `columns` — a renamed key fails there rather than arriving as a column of NULLs.
- Removed a debug block in `build_untyped_compendia()` that printed every concord pair touching `DrugCentral:4970`. Its last line read `dicts["DrugCentral:4970"]` unconditionally whenever a concord's first pair carried a DrugCentral prefix, so the 256 GB rule would `KeyError` the moment that one CURIE left the data.
- `docs/sources/CLAUDE.md` gains a section on the failure mode behind #1086: a SPARQL query for a renamed predicate returns an empty result set rather than an error, and agreement between sources is what hides it.

## Test plan

- `uv run pytest -m unit` — 643 pass. New coverage: the structure emit (including the semicolon case and the CHARGE exemption), `make_chebi_roles()`'s empty guard and sort/dedup, the `Property` predicates round-tripping, and the `Property.parquet` export.
- `uv run pytest --network` — `get_roles()` against a live UberGraph.
- All four linters clean.
- Verified against the real 922 MB SDF: every per-tag count matches an independent characterization of the file (192,445 SMILES; 181,048 InChI; 15,613 CHARGE; 3,997 semicolon-bearing InChIs preserved intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
