### PR TITLE
Fix the relocated FRINK SPARQL endpoint, and make HMDB's Cloudflare block recoverable by hand

### DIFF
--- a/docs/sources/DownloadPatterns.md
+++ b/docs/sources/DownloadPatterns.md
@@ -51,7 +51,21 @@ cannot succeed unattended.
 **What Babel does** — `pull_via_urllib()` calls `raise_if_cloudflare_challenge()`
 (`src/babel_utils.py`) before its retry/backoff path. On a challenge response it raises immediately
 with a `RuntimeError` naming both the URL and the local path the file is expected at, so the
-operator can download it in a browser, drop it in place, and re-run the rule.
+operator can download it in a browser, drop it in place, and re-run the rule. Two signals are
+checked: the `cf-mitigated: challenge` header, and — as a fallback should Cloudflare rename that
+header — a `content-security-policy` allowing `challenges.cloudflare.com`, which a challenge page
+needs in order to load the widget at all.
+
+**Placing the file by hand has to actually work.** `pull_via_urllib()` deletes its target before
+every attempt, so a handler whose error message says "put it here and re-run" must skip the
+download when the file is already present, or the manual copy is wiped and the rule fails
+identically forever. `pull_hmdb()` (`src/datahandlers/hmdb.py`) is the worked example; copy that
+shape rather than relying on `pull_via_urllib()` alone.
+
+**A challenge still burns the rule's Snakemake `retries`.** Snakemake has no way to mark a failure
+as non-retryable from inside the rule, so `get_HMDB` re-runs its three times. Each one fails in
+well under a second, without backoff, and the last error the operator sees is the actionable one —
+not worth machinery to suppress.
 
 **When a new source starts doing this** — the detection is generic, so no code change is needed; the
 rule will simply fail fast with instructions. Record the manual download in `config.yaml` under

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -277,17 +277,33 @@ def raise_if_cloudflare_challenge(download_url: str, local_file_name: str, error
     Retrying or changing the User-Agent won't help: this is served identically to a real
     browser. Raise immediately with instructions for a human to download the file manually.
 
+    A challenge page also has to load Cloudflare's widget, so it carries a Content-Security-Policy
+    naming `challenges.cloudflare.com`. That is checked as a fallback: it is a property of how the
+    page works rather than a label Cloudflare chose, so it still identifies a challenge if
+    `cf-mitigated` is ever renamed. A plain 403 (a wrong URL, an IP block) carries neither signal
+    and keeps the caller's normal retry.
+
     Only an HTTPError carries response headers; a plain URLError (DNS failure, connection
     refused) has no `.headers` at all, so we getattr() rather than narrowing the caller's
     except clause to HTTPError and duplicating its retry body.
     """
     headers = getattr(error, "headers", None)
-    if headers is not None and headers.get("cf-mitigated") == "challenge":
-        raise RuntimeError(
-            f"{download_url} is behind a Cloudflare bot challenge (cf-mitigated: challenge) and cannot be "
-            "downloaded automatically. Please download the file manually in a browser and place it at "
-            f"{local_file_name}, then re-run this rule."
-        )
+    if headers is None:
+        return
+
+    if headers.get("cf-mitigated") == "challenge":
+        signal = "cf-mitigated: challenge"
+    elif "challenges.cloudflare.com" in (headers.get("content-security-policy") or ""):
+        signal = "a content-security-policy allowing challenges.cloudflare.com"
+    else:
+        return
+
+    raise RuntimeError(
+        f"{download_url} is behind a Cloudflare bot challenge ({signal}) and cannot be downloaded "
+        "automatically: the challenge is served to real browsers too, so neither retrying nor changing "
+        "the User-Agent will get past it. Please download the file manually in a browser and place it at "
+        f"{local_file_name}, then re-run this rule -- an already-present file is used as-is."
+    )
 
 
 def pull_via_urllib(url: str, in_file_name: str, decompress=True, subpath=None, verify_gzip=False):

--- a/src/createcompendia/anatomy.py
+++ b/src/createcompendia/anatomy.py
@@ -307,7 +307,7 @@ def build_wikidata_cell_relationships(outdir, metadata_yaml):
           ?wd wdtn:P7963 ?cl .
           ?wd wdt:P2892 ?umls .
         }"""
-    frink_wikidata_url = "https://frink.apps.renci.org/federation/sparql"
+    frink_wikidata_url = "https://apps.okn.us/federation/sparql"
     response = requests.post(frink_wikidata_url, data={"query": sparql})
     if not response.ok:
         raise RuntimeError(f"Could not query {frink_wikidata_url}: {response.status_code} {response.reason}")

--- a/src/datahandlers/hmdb.py
+++ b/src/datahandlers/hmdb.py
@@ -5,12 +5,28 @@ import xmltodict
 
 from src.babel_utils import pull_via_urllib
 from src.prefixes import HMDB
+from src.util import get_config, get_logger
+
+logger = get_logger(__name__)
+
+HMDB_DOWNLOAD_URL = "https://hmdb.ca/system/downloads/current/"
+HMDB_ZIP_FILENAME = "hmdb_metabolites.zip"
 
 
 def pull_hmdb():
-    dname = pull_via_urllib(
-        "https://hmdb.ca/system/downloads/current/", "hmdb_metabolites.zip", decompress=False, subpath="HMDB"
-    )
+    """Download and unpack the HMDB metabolites dump.
+
+    HMDB sits behind a Cloudflare bot challenge that no unattended client can pass, so
+    raise_if_cloudflare_challenge() tells the operator to fetch the zip in a browser and drop it
+    in place. An already-present zip is therefore used as-is rather than re-downloaded --
+    pull_via_urllib() deletes its target before each attempt, so without this the manual copy
+    would be wiped and the rule would fail again the same way.
+    """
+    dname = path.join(get_config()["download_directory"], "HMDB", HMDB_ZIP_FILENAME)
+    if path.exists(dname):
+        logger.info("Using previously downloaded %s instead of downloading it again.", dname)
+    else:
+        dname = pull_via_urllib(HMDB_DOWNLOAD_URL, HMDB_ZIP_FILENAME, decompress=False, subpath="HMDB")
     ddir = path.dirname(dname)
     with ZipFile(dname, "r") as zipObj:
         zipObj.extractall(ddir)

--- a/tests/babel_utils/test_cloudflare_challenge.py
+++ b/tests/babel_utils/test_cloudflare_challenge.py
@@ -36,6 +36,24 @@ def _http_error(raw_headers: str) -> urllib.error.HTTPError:
 
 
 @pytest.mark.unit
+def test_challenge_detected_from_csp_when_cf_mitigated_is_absent():
+    """A challenge page should still be recognized from its Cloudflare-widget CSP alone.
+
+    `cf-mitigated` is a label Cloudflare chose and could rename; having to load the widget from
+    challenges.cloudflare.com is how the page works. Header copied verbatim from a live
+    https://hmdb.ca/system/downloads/current/hmdb_metabolites.zip 403 on 2026-09-11, trimmed to
+    the directives that name the widget.
+    """
+    csp = (
+        "content-security-policy: default-src 'none'; script-src 'nonce-sdE6vqamOBuKVQaBr2ZyGU' "
+        "'unsafe-eval' https://challenges.cloudflare.com; frame-src 'self' "
+        "https://challenges.cloudflare.com blob:"
+    )
+    with pytest.raises(RuntimeError, match="Cloudflare bot challenge"):
+        raise_if_cloudflare_challenge("https://example.com/file.zip", "/downloads/SOURCE/file.zip", _http_error(csp))
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize("header_casing", ["cf-mitigated: challenge", "Cf-Mitigated: challenge"])
 def test_cloudflare_challenge_raises_actionable_error(header_casing):
     """A 403 with `cf-mitigated: challenge` (in any casing) should raise a RuntimeError naming the

--- a/tests/createcompendia/test_anatomy.py
+++ b/tests/createcompendia/test_anatomy.py
@@ -1,0 +1,22 @@
+"""Tests for src/createcompendia/anatomy.py."""
+
+import pytest
+
+from src.createcompendia.anatomy import build_wikidata_cell_relationships
+from src.prefixes import CL, UMLS, WIKIDATA
+
+# WIKIDATA CELL RELATIONSHIPS
+
+
+@pytest.mark.network
+def test_build_wikidata_cell_relationships(tmp_path):
+    """The Wikidata CL/UMLS SPARQL endpoint should still answer and yield usable concord rows."""
+    build_wikidata_cell_relationships(str(tmp_path), str(tmp_path / "wikidata.yaml"))
+
+    lines = (tmp_path / WIKIDATA).read_text().splitlines()
+    assert len(lines) > 100, "Expected thousands of unique UMLS/CL pairs, got a near-empty concord"
+    for line in lines:
+        umls_curie, relation, cl_curie = line.split("\t")
+        assert umls_curie.startswith(f"{UMLS}:")
+        assert relation == "eq"
+        assert cl_curie.startswith(f"{CL}:")

--- a/tests/datahandlers/test_hmdb.py
+++ b/tests/datahandlers/test_hmdb.py
@@ -1,52 +1,70 @@
-"""Network tests for the HMDB download.
+"""Tests for the HMDB download.
 
-These verify that HMDB's download URL is reachable with the User-Agent Babel sends.
-Run with: uv run pytest --network tests/datahandlers/test_hmdb.py
+HMDB fronts its download URL with a Cloudflare bot challenge, so the unattended download cannot
+succeed and the operator has to place the zip by hand. These tests cover the two halves of that:
+that Babel still recognizes the live response as a challenge, and that a hand-placed zip is
+actually used on the next run.
+
+Run the network test with: uv run pytest --network tests/datahandlers/test_hmdb.py
 """
 
 import urllib.error
 import urllib.request
+import zipfile
+from unittest.mock import patch
 
 import pytest
 
-from src.babel_utils import get_user_agent
+from src.babel_utils import get_user_agent, raise_if_cloudflare_challenge
+from src.datahandlers.hmdb import HMDB_DOWNLOAD_URL, HMDB_ZIP_FILENAME, pull_hmdb
+from src.util import get_config
 
-pytestmark = [pytest.mark.network]
-
-HMDB_ZIP_URL = "https://hmdb.ca/system/downloads/current/hmdb_metabolites.zip"
+HMDB_ZIP_URL = HMDB_DOWNLOAD_URL + HMDB_ZIP_FILENAME
 
 
-def test_hmdb_url_accessible_with_user_agent():
-    """HMDB download URL should be reachable with our User-Agent (not 403)."""
+# LIVE HMDB DOWNLOAD
+
+
+@pytest.mark.network
+def test_hmdb_download_either_works_or_is_a_recognized_challenge():
+    """The live HMDB URL should either serve the file or be recognized as a Cloudflare challenge.
+
+    As of 2026-09-11 it is the latter (HTTP 403, `cf-mitigated: challenge`). This asserts the
+    disjunction rather than reachability because both outcomes are fine -- what is not fine is a
+    403 Babel fails to classify, which would send the rule into a retry loop with an unhelpful
+    error instead of telling the operator to fetch the zip by hand.
+    """
     req = urllib.request.Request(HMDB_ZIP_URL, headers={"User-Agent": get_user_agent()})
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
-            # Read just the first 1 KB to confirm the body streams without error.
-            chunk = resp.read(1024)
-        assert len(chunk) > 0, "HMDB returned an empty body"
-    except urllib.error.HTTPError as e:
-        pytest.fail(
-            f"HMDB download URL returned HTTP {e.code} with User-Agent '{get_user_agent()}'. "
-            "The server may be blocking non-browser clients or the HPC egress IP."
-        )
+            assert len(resp.read(1024)) > 0, "HMDB returned an empty body"
+    except urllib.error.URLError as e:
+        with pytest.raises(RuntimeError, match="Cloudflare bot challenge"):
+            raise_if_cloudflare_challenge(HMDB_ZIP_URL, "babel_downloads/HMDB/" + HMDB_ZIP_FILENAME, e)
 
 
-def test_hmdb_url_rejects_no_user_agent():
-    """HMDB returns 403 when no User-Agent is set (raw urllib default).
+# MANUALLY PLACED ZIP
 
-    This documents the known behaviour that motivates always setting our User-Agent.
-    If HMDB changes policy and starts accepting bare requests, this test will fail
-    and should be removed.
+
+@pytest.mark.unit
+def test_pull_hmdb_uses_a_manually_placed_zip(tmp_path):
+    """A zip already sitting in the download directory should be unpacked without re-downloading.
+
+    This is what makes the "place it here and re-run" instruction in the Cloudflare error true:
+    pull_via_urllib() deletes its target before each attempt, so a manual copy would otherwise be
+    wiped and the rule would fail the same way forever.
     """
-    # urllib's default User-Agent is "Python-urllib/<version>", which HMDB rejects.
-    req = urllib.request.Request(HMDB_ZIP_URL)
-    try:
-        with urllib.request.urlopen(req, timeout=30):
-            pass
-        # If we get here the server accepted the bare request — document the change.
-        pytest.xfail("HMDB no longer rejects bare Python-urllib requests; remove this test.")
-    except urllib.error.HTTPError as e:
-        if e.code == 403:
-            pass  # expected — server rejects bare requests
-        else:
-            pytest.fail(f"Unexpected HTTP {e.code} from HMDB (expected 403 for bare UA)")
+    hmdb_dir = tmp_path / "HMDB"
+    hmdb_dir.mkdir()
+    with zipfile.ZipFile(hmdb_dir / HMDB_ZIP_FILENAME, "w") as zipobj:
+        zipobj.writestr("hmdb_metabolites.xml", "<hmdb/>")
+
+    config = {**get_config(), "download_directory": str(tmp_path)}
+    with (
+        patch("src.datahandlers.hmdb.get_config", return_value=config),
+        patch("src.datahandlers.hmdb.pull_via_urllib") as pull,
+    ):
+        pull_hmdb()
+
+    pull.assert_not_called()
+    assert (hmdb_dir / "hmdb_metabolites.xml").read_text() == "<hmdb/>"


### PR DESCRIPTION
Two unrelated-in-cause but both-download-layer failures.

## The FRINK SPARQL endpoint moved

`build_wikidata_cell_relationships()` queries the FRINK federation endpoint for the Wikidata items carrying both a Cell Ontology ID (`wd:P7963`) and a UMLS CUI (`wd:P2892`). That endpoint moved from `https://frink.apps.renci.org/federation/sparql` to `https://apps.okn.us/federation/sparql`; the old host now answers 503, so the query raised `RuntimeError` and took the anatomy build down with it. It was a single literal in `src/createcompendia/anatomy.py`, the only occurrence in the repo outside the frozen `releases/*/metadata/` YAMLs.

Verified against the live endpoint: same shape of results as before, 597 unique UMLS↔CL pairs written to the WIKIDATA concord in about a quarter of a second. `tests/createcompendia/test_anatomy.py` is a new `network` test that runs the query end to end and asserts the concord rows are `UMLS:… eq CL:…`; it fails against the old URL.

## HMDB's Cloudflare block was detected but not recoverable

`get_HMDB` has been failing with HTTP 403. The `cf-mitigated: challenge` header is still being sent and `raise_if_cloudflare_challenge()` still fires on it, so detection was never the broken part — the recovery instruction it prints was. The message tells the operator to place the zip at `babel_downloads/HMDB/hmdb_metabolites.zip` and re-run, but `pull_via_urllib()` unlinks its target at the top of every attempt, so it wiped the manual copy and failed identically. `pull_hmdb()` now unpacks an already-present zip instead of re-downloading, which is what makes that instruction true.

A challenge is now also recognized from a `content-security-policy` allowing `challenges.cloudflare.com`, as a fallback should Cloudflare rename `cf-mitigated`: loading the widget is how the page works rather than a label Cloudflare chose. The CSP fixture is copied verbatim from a live HMDB 403, and the test was confirmed to fail with the fallback removed.

Left alone deliberately: a challenge still burns the rule's three Snakemake `retries`, because Snakemake cannot mark a failure non-retryable from inside a rule. Each attempt fails in well under a second with no backoff and the last error the operator sees is the actionable one. Noted in `docs/sources/DownloadPatterns.md` rather than worked around.

The two old HMDB network tests are replaced by one. They asserted the download URL was reachable — now permanently false — and the second implied the User-Agent was what got us through, which it never was (a Chrome UA gets the same 403). The replacement asserts the live response either serves the file or is classified as a challenge, so an unclassifiable 403 is the thing that fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
